### PR TITLE
Enhancement: Build linux/arm/v6 arch image for alpine:edge and alpine:3.14

### DIFF
--- a/.github/workflows/ci-master-pr.yml
+++ b/.github/workflows/ci-master-pr.yml
@@ -94,7 +94,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/386,linux/amd64,linux/arm,linux/arm/v7,linux/arm64,linux/s390x
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -109,7 +109,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -124,7 +124,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
@@ -224,7 +224,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/386,linux/amd64,linux/arm,linux/arm/v7,linux/arm64,linux/s390x
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -239,7 +239,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -254,7 +254,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
@@ -355,7 +355,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/386,linux/amd64,linux/arm,linux/arm/v7,linux/arm64,linux/s390x
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -370,7 +370,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -385,7 +385,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
@@ -485,7 +485,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/386,linux/amd64,linux/arm,linux/arm/v7,linux/arm64,linux/s390x
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -500,7 +500,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -515,7 +515,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}

--- a/generate/templates/.github/workflows/ci-master-pr.yml.ps1
+++ b/generate/templates/.github/workflows/ci-master-pr.yml.ps1
@@ -110,7 +110,7 @@ $VARIANTS | % {
         platforms: $(
           if ($_['_metadata']['distro'] -eq 'alpine') {
               if ($_['_metadata']['distro_version'] -in @( 'edge', '3.14' ) ) {
-                'linux/386,linux/amd64,linux/arm,linux/arm/v7,linux/arm64,linux/s390x'
+                'linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x'
               }elseif ($_['_metadata']['distro_version'] -in @( '3.3', '3.4', '3.5' ) ) {
                 # 'linux/386,linux/amd64,linux/arm64'
                 'linux/amd64'
@@ -136,7 +136,7 @@ $VARIANTS | % {
         platforms: $(
           if ($_['_metadata']['distro'] -eq 'alpine') {
               if ($_['_metadata']['distro_version'] -in @( 'edge', '3.14' ) ) {
-                'linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x'
+                'linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x'
               }elseif ($_['_metadata']['distro_version'] -in @( '3.3', '3.4', '3.5' ) ) {
                 # 'linux/386,linux/amd64,linux/arm64'
                 'linux/amd64'
@@ -162,7 +162,7 @@ $VARIANTS | % {
         platforms: $(
           if ($_['_metadata']['distro'] -eq 'alpine') {
               if ($_['_metadata']['distro_version'] -in @( 'edge', '3.14' ) ) {
-                'linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x'
+                'linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x'
               }elseif ($_['_metadata']['distro_version'] -in @( '3.3', '3.4', '3.5' ) ) {
                 # 'linux/386,linux/amd64,linux/arm64'
                 'linux/amd64'


### PR DESCRIPTION
Previously  in #1 and #2, there was a duplicate build. `linux/arm` is actually `linux/arm/v7`.

This change fixes the build for `linux/arm/v6`.

Archs: `linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x`