### PR TITLE
Fix (ci): Regenerate `.github/workflows/ci-master-pr.yml` to use $GITHUB_ENV, github.ref_name, and bump actions to node 16

### DIFF
--- a/.github/workflows/ci-master-pr.yml
+++ b/.github/workflows/ci-master-pr.yml
@@ -18,7 +18,7 @@ jobs:
       VARIANT_BUILD_DIR: variants/v1.0.11-alpine-3.15
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Display system info (linux)
       run: |
@@ -35,14 +35,14 @@ jobs:
 
     # See: https://github.com/docker/build-push-action/blob/v2.6.1/docs/advanced/cache.md#github-cache
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@master
 
     - name: Cache Docker layers
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /tmp/.buildx-cache
         key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -51,8 +51,6 @@ jobs:
 
     - name: Prepare
       id: prep
-      env:
-        DOCKERHUB_REGISTRY_USER: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
       run: |
         set -e
 
@@ -60,25 +58,26 @@ jobs:
         # CI_PROJECT_NAMESPACE=$( echo "${{ github.repository }}" | cut -d '/' -f 1 )
         # CI_PROJECT_NAME=$( echo "${{ github.repository }}" | cut -d '/' -f 2 )
 
-        # Get <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. . E.g. 'master', 'v1.2.3'
+        # Get ref, i.e. <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. 'master' or 'v1.2.3'
         REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+
         # Get commit hash E.g. 'b29758a'
         SHA_SHORT=$( echo "${GITHUB_SHA}" | cut -c1-7 )
 
-        # Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
+        # Generate the final tags. E.g. 'master-mytag' and 'master-b29758a-mytag'
         VARIANT_TAG_WITH_REF="${REF}-${VARIANT_TAG}"
         VARIANT_TAG_WITH_REF_AND_SHA_SHORT="${REF}-${SHA_SHORT}-${VARIANT_TAG}"
 
-        # Set step output(s)
-        # echo "::set-output name=CI_PROJECT_NAMESPACE::$CI_PROJECT_NAMESPACE"
-        # echo "::set-output name=CI_PROJECT_NAME::$CI_PROJECT_NAME"
-        # echo "::set-output name=REF::$REF"
-        # echo "::set-output name=SHA_SHORT::$SHA_SHORT"
-        # echo "::set-output name=REF_AND_SHA_SHORT::$REF_AND_SHA_SHORT"
-        echo "::set-output name=CONTEXT::$VARIANT_BUILD_DIR"
-        echo "::set-output name=VARIANT_TAG::$VARIANT_TAG"
-        echo "::set-output name=VARIANT_TAG_WITH_REF::$VARIANT_TAG_WITH_REF"
-        echo "::set-output name=VARIANT_TAG_WITH_REF_AND_SHA_SHORT::$VARIANT_TAG_WITH_REF_AND_SHA_SHORT"
+        # Pass variables to next step
+        # echo "CI_PROJECT_NAMESPACE=$CI_PROJECT_NAMESPACE" >> $GITHUB_ENV
+        # echo "CI_PROJECT_NAME=$CI_PROJECT_NAME" >> $GITHUB_ENV
+        # echo "REF=$REF" >> $GITHUB_ENV
+        # echo "SHA_SHORT=$SHA_SHORT" >> $GITHUB_ENV
+        # echo "REF_AND_SHA_SHORT=$REF_AND_SHA_SHORT" >> $GITHUB_ENV
+        echo "VARIANT_BUILD_DIR=$VARIANT_BUILD_DIR" >> $GITHUB_ENV
+        echo "VARIANT_TAG=$VARIANT_TAG" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF=$VARIANT_TAG_WITH_REF" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF_AND_SHA_SHORT=$VARIANT_TAG_WITH_REF_AND_SHA_SHORT" >> $GITHUB_ENV
 
     - name: Login to docker registry
       if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
@@ -91,14 +90,14 @@ jobs:
       id: docker_build_pr
       # Run only on pull requests
       if: github.event_name == 'pull_request'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -106,28 +105,28 @@ jobs:
       id: docker_build_master
       # Run only on master
       if: github.ref == 'refs/heads/master'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Build and push (release)
       id: docker_build_release
       if: startsWith(github.ref, 'refs/tags/')
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -145,7 +144,7 @@ jobs:
       VARIANT_BUILD_DIR: variants/v1.0.11-sops-ssh-alpine-3.15
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Display system info (linux)
       run: |
@@ -162,14 +161,14 @@ jobs:
 
     # See: https://github.com/docker/build-push-action/blob/v2.6.1/docs/advanced/cache.md#github-cache
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@master
 
     - name: Cache Docker layers
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /tmp/.buildx-cache
         key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -178,8 +177,6 @@ jobs:
 
     - name: Prepare
       id: prep
-      env:
-        DOCKERHUB_REGISTRY_USER: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
       run: |
         set -e
 
@@ -187,25 +184,26 @@ jobs:
         # CI_PROJECT_NAMESPACE=$( echo "${{ github.repository }}" | cut -d '/' -f 1 )
         # CI_PROJECT_NAME=$( echo "${{ github.repository }}" | cut -d '/' -f 2 )
 
-        # Get <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. . E.g. 'master', 'v1.2.3'
+        # Get ref, i.e. <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. 'master' or 'v1.2.3'
         REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+
         # Get commit hash E.g. 'b29758a'
         SHA_SHORT=$( echo "${GITHUB_SHA}" | cut -c1-7 )
 
-        # Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
+        # Generate the final tags. E.g. 'master-mytag' and 'master-b29758a-mytag'
         VARIANT_TAG_WITH_REF="${REF}-${VARIANT_TAG}"
         VARIANT_TAG_WITH_REF_AND_SHA_SHORT="${REF}-${SHA_SHORT}-${VARIANT_TAG}"
 
-        # Set step output(s)
-        # echo "::set-output name=CI_PROJECT_NAMESPACE::$CI_PROJECT_NAMESPACE"
-        # echo "::set-output name=CI_PROJECT_NAME::$CI_PROJECT_NAME"
-        # echo "::set-output name=REF::$REF"
-        # echo "::set-output name=SHA_SHORT::$SHA_SHORT"
-        # echo "::set-output name=REF_AND_SHA_SHORT::$REF_AND_SHA_SHORT"
-        echo "::set-output name=CONTEXT::$VARIANT_BUILD_DIR"
-        echo "::set-output name=VARIANT_TAG::$VARIANT_TAG"
-        echo "::set-output name=VARIANT_TAG_WITH_REF::$VARIANT_TAG_WITH_REF"
-        echo "::set-output name=VARIANT_TAG_WITH_REF_AND_SHA_SHORT::$VARIANT_TAG_WITH_REF_AND_SHA_SHORT"
+        # Pass variables to next step
+        # echo "CI_PROJECT_NAMESPACE=$CI_PROJECT_NAMESPACE" >> $GITHUB_ENV
+        # echo "CI_PROJECT_NAME=$CI_PROJECT_NAME" >> $GITHUB_ENV
+        # echo "REF=$REF" >> $GITHUB_ENV
+        # echo "SHA_SHORT=$SHA_SHORT" >> $GITHUB_ENV
+        # echo "REF_AND_SHA_SHORT=$REF_AND_SHA_SHORT" >> $GITHUB_ENV
+        echo "VARIANT_BUILD_DIR=$VARIANT_BUILD_DIR" >> $GITHUB_ENV
+        echo "VARIANT_TAG=$VARIANT_TAG" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF=$VARIANT_TAG_WITH_REF" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF_AND_SHA_SHORT=$VARIANT_TAG_WITH_REF_AND_SHA_SHORT" >> $GITHUB_ENV
 
     - name: Login to docker registry
       if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
@@ -218,14 +216,14 @@ jobs:
       id: docker_build_pr
       # Run only on pull requests
       if: github.event_name == 'pull_request'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -233,28 +231,28 @@ jobs:
       id: docker_build_master
       # Run only on master
       if: github.ref == 'refs/heads/master'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Build and push (release)
       id: docker_build_release
       if: startsWith(github.ref, 'refs/tags/')
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
           ${{ github.repository }}:latest
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
@@ -273,7 +271,7 @@ jobs:
       VARIANT_BUILD_DIR: variants/v0.14.9-alpine-3.14
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Display system info (linux)
       run: |
@@ -290,14 +288,14 @@ jobs:
 
     # See: https://github.com/docker/build-push-action/blob/v2.6.1/docs/advanced/cache.md#github-cache
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@master
 
     - name: Cache Docker layers
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /tmp/.buildx-cache
         key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -306,8 +304,6 @@ jobs:
 
     - name: Prepare
       id: prep
-      env:
-        DOCKERHUB_REGISTRY_USER: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
       run: |
         set -e
 
@@ -315,25 +311,26 @@ jobs:
         # CI_PROJECT_NAMESPACE=$( echo "${{ github.repository }}" | cut -d '/' -f 1 )
         # CI_PROJECT_NAME=$( echo "${{ github.repository }}" | cut -d '/' -f 2 )
 
-        # Get <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. . E.g. 'master', 'v1.2.3'
+        # Get ref, i.e. <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. 'master' or 'v1.2.3'
         REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+
         # Get commit hash E.g. 'b29758a'
         SHA_SHORT=$( echo "${GITHUB_SHA}" | cut -c1-7 )
 
-        # Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
+        # Generate the final tags. E.g. 'master-mytag' and 'master-b29758a-mytag'
         VARIANT_TAG_WITH_REF="${REF}-${VARIANT_TAG}"
         VARIANT_TAG_WITH_REF_AND_SHA_SHORT="${REF}-${SHA_SHORT}-${VARIANT_TAG}"
 
-        # Set step output(s)
-        # echo "::set-output name=CI_PROJECT_NAMESPACE::$CI_PROJECT_NAMESPACE"
-        # echo "::set-output name=CI_PROJECT_NAME::$CI_PROJECT_NAME"
-        # echo "::set-output name=REF::$REF"
-        # echo "::set-output name=SHA_SHORT::$SHA_SHORT"
-        # echo "::set-output name=REF_AND_SHA_SHORT::$REF_AND_SHA_SHORT"
-        echo "::set-output name=CONTEXT::$VARIANT_BUILD_DIR"
-        echo "::set-output name=VARIANT_TAG::$VARIANT_TAG"
-        echo "::set-output name=VARIANT_TAG_WITH_REF::$VARIANT_TAG_WITH_REF"
-        echo "::set-output name=VARIANT_TAG_WITH_REF_AND_SHA_SHORT::$VARIANT_TAG_WITH_REF_AND_SHA_SHORT"
+        # Pass variables to next step
+        # echo "CI_PROJECT_NAMESPACE=$CI_PROJECT_NAMESPACE" >> $GITHUB_ENV
+        # echo "CI_PROJECT_NAME=$CI_PROJECT_NAME" >> $GITHUB_ENV
+        # echo "REF=$REF" >> $GITHUB_ENV
+        # echo "SHA_SHORT=$SHA_SHORT" >> $GITHUB_ENV
+        # echo "REF_AND_SHA_SHORT=$REF_AND_SHA_SHORT" >> $GITHUB_ENV
+        echo "VARIANT_BUILD_DIR=$VARIANT_BUILD_DIR" >> $GITHUB_ENV
+        echo "VARIANT_TAG=$VARIANT_TAG" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF=$VARIANT_TAG_WITH_REF" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF_AND_SHA_SHORT=$VARIANT_TAG_WITH_REF_AND_SHA_SHORT" >> $GITHUB_ENV
 
     - name: Login to docker registry
       if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
@@ -346,14 +343,14 @@ jobs:
       id: docker_build_pr
       # Run only on pull requests
       if: github.event_name == 'pull_request'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -361,28 +358,28 @@ jobs:
       id: docker_build_master
       # Run only on master
       if: github.ref == 'refs/heads/master'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Build and push (release)
       id: docker_build_release
       if: startsWith(github.ref, 'refs/tags/')
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -400,7 +397,7 @@ jobs:
       VARIANT_BUILD_DIR: variants/v0.14.9-sops-ssh-alpine-3.14
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Display system info (linux)
       run: |
@@ -417,14 +414,14 @@ jobs:
 
     # See: https://github.com/docker/build-push-action/blob/v2.6.1/docs/advanced/cache.md#github-cache
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@master
 
     - name: Cache Docker layers
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /tmp/.buildx-cache
         key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -433,8 +430,6 @@ jobs:
 
     - name: Prepare
       id: prep
-      env:
-        DOCKERHUB_REGISTRY_USER: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
       run: |
         set -e
 
@@ -442,25 +437,26 @@ jobs:
         # CI_PROJECT_NAMESPACE=$( echo "${{ github.repository }}" | cut -d '/' -f 1 )
         # CI_PROJECT_NAME=$( echo "${{ github.repository }}" | cut -d '/' -f 2 )
 
-        # Get <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. . E.g. 'master', 'v1.2.3'
+        # Get ref, i.e. <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. 'master' or 'v1.2.3'
         REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+
         # Get commit hash E.g. 'b29758a'
         SHA_SHORT=$( echo "${GITHUB_SHA}" | cut -c1-7 )
 
-        # Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
+        # Generate the final tags. E.g. 'master-mytag' and 'master-b29758a-mytag'
         VARIANT_TAG_WITH_REF="${REF}-${VARIANT_TAG}"
         VARIANT_TAG_WITH_REF_AND_SHA_SHORT="${REF}-${SHA_SHORT}-${VARIANT_TAG}"
 
-        # Set step output(s)
-        # echo "::set-output name=CI_PROJECT_NAMESPACE::$CI_PROJECT_NAMESPACE"
-        # echo "::set-output name=CI_PROJECT_NAME::$CI_PROJECT_NAME"
-        # echo "::set-output name=REF::$REF"
-        # echo "::set-output name=SHA_SHORT::$SHA_SHORT"
-        # echo "::set-output name=REF_AND_SHA_SHORT::$REF_AND_SHA_SHORT"
-        echo "::set-output name=CONTEXT::$VARIANT_BUILD_DIR"
-        echo "::set-output name=VARIANT_TAG::$VARIANT_TAG"
-        echo "::set-output name=VARIANT_TAG_WITH_REF::$VARIANT_TAG_WITH_REF"
-        echo "::set-output name=VARIANT_TAG_WITH_REF_AND_SHA_SHORT::$VARIANT_TAG_WITH_REF_AND_SHA_SHORT"
+        # Pass variables to next step
+        # echo "CI_PROJECT_NAMESPACE=$CI_PROJECT_NAMESPACE" >> $GITHUB_ENV
+        # echo "CI_PROJECT_NAME=$CI_PROJECT_NAME" >> $GITHUB_ENV
+        # echo "REF=$REF" >> $GITHUB_ENV
+        # echo "SHA_SHORT=$SHA_SHORT" >> $GITHUB_ENV
+        # echo "REF_AND_SHA_SHORT=$REF_AND_SHA_SHORT" >> $GITHUB_ENV
+        echo "VARIANT_BUILD_DIR=$VARIANT_BUILD_DIR" >> $GITHUB_ENV
+        echo "VARIANT_TAG=$VARIANT_TAG" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF=$VARIANT_TAG_WITH_REF" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF_AND_SHA_SHORT=$VARIANT_TAG_WITH_REF_AND_SHA_SHORT" >> $GITHUB_ENV
 
     - name: Login to docker registry
       if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
@@ -473,14 +469,14 @@ jobs:
       id: docker_build_pr
       # Run only on pull requests
       if: github.event_name == 'pull_request'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -488,28 +484,28 @@ jobs:
       id: docker_build_master
       # Run only on master
       if: github.ref == 'refs/heads/master'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Build and push (release)
       id: docker_build_release
       if: startsWith(github.ref, 'refs/tags/')
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -527,7 +523,7 @@ jobs:
       VARIANT_BUILD_DIR: variants/v0.14.4-alpine-3.13
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Display system info (linux)
       run: |
@@ -544,14 +540,14 @@ jobs:
 
     # See: https://github.com/docker/build-push-action/blob/v2.6.1/docs/advanced/cache.md#github-cache
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@master
 
     - name: Cache Docker layers
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /tmp/.buildx-cache
         key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -560,8 +556,6 @@ jobs:
 
     - name: Prepare
       id: prep
-      env:
-        DOCKERHUB_REGISTRY_USER: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
       run: |
         set -e
 
@@ -569,25 +563,26 @@ jobs:
         # CI_PROJECT_NAMESPACE=$( echo "${{ github.repository }}" | cut -d '/' -f 1 )
         # CI_PROJECT_NAME=$( echo "${{ github.repository }}" | cut -d '/' -f 2 )
 
-        # Get <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. . E.g. 'master', 'v1.2.3'
+        # Get ref, i.e. <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. 'master' or 'v1.2.3'
         REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+
         # Get commit hash E.g. 'b29758a'
         SHA_SHORT=$( echo "${GITHUB_SHA}" | cut -c1-7 )
 
-        # Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
+        # Generate the final tags. E.g. 'master-mytag' and 'master-b29758a-mytag'
         VARIANT_TAG_WITH_REF="${REF}-${VARIANT_TAG}"
         VARIANT_TAG_WITH_REF_AND_SHA_SHORT="${REF}-${SHA_SHORT}-${VARIANT_TAG}"
 
-        # Set step output(s)
-        # echo "::set-output name=CI_PROJECT_NAMESPACE::$CI_PROJECT_NAMESPACE"
-        # echo "::set-output name=CI_PROJECT_NAME::$CI_PROJECT_NAME"
-        # echo "::set-output name=REF::$REF"
-        # echo "::set-output name=SHA_SHORT::$SHA_SHORT"
-        # echo "::set-output name=REF_AND_SHA_SHORT::$REF_AND_SHA_SHORT"
-        echo "::set-output name=CONTEXT::$VARIANT_BUILD_DIR"
-        echo "::set-output name=VARIANT_TAG::$VARIANT_TAG"
-        echo "::set-output name=VARIANT_TAG_WITH_REF::$VARIANT_TAG_WITH_REF"
-        echo "::set-output name=VARIANT_TAG_WITH_REF_AND_SHA_SHORT::$VARIANT_TAG_WITH_REF_AND_SHA_SHORT"
+        # Pass variables to next step
+        # echo "CI_PROJECT_NAMESPACE=$CI_PROJECT_NAMESPACE" >> $GITHUB_ENV
+        # echo "CI_PROJECT_NAME=$CI_PROJECT_NAME" >> $GITHUB_ENV
+        # echo "REF=$REF" >> $GITHUB_ENV
+        # echo "SHA_SHORT=$SHA_SHORT" >> $GITHUB_ENV
+        # echo "REF_AND_SHA_SHORT=$REF_AND_SHA_SHORT" >> $GITHUB_ENV
+        echo "VARIANT_BUILD_DIR=$VARIANT_BUILD_DIR" >> $GITHUB_ENV
+        echo "VARIANT_TAG=$VARIANT_TAG" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF=$VARIANT_TAG_WITH_REF" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF_AND_SHA_SHORT=$VARIANT_TAG_WITH_REF_AND_SHA_SHORT" >> $GITHUB_ENV
 
     - name: Login to docker registry
       if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
@@ -600,14 +595,14 @@ jobs:
       id: docker_build_pr
       # Run only on pull requests
       if: github.event_name == 'pull_request'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -615,28 +610,28 @@ jobs:
       id: docker_build_master
       # Run only on master
       if: github.ref == 'refs/heads/master'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Build and push (release)
       id: docker_build_release
       if: startsWith(github.ref, 'refs/tags/')
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -654,7 +649,7 @@ jobs:
       VARIANT_BUILD_DIR: variants/v0.14.4-sops-ssh-alpine-3.13
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Display system info (linux)
       run: |
@@ -671,14 +666,14 @@ jobs:
 
     # See: https://github.com/docker/build-push-action/blob/v2.6.1/docs/advanced/cache.md#github-cache
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@master
 
     - name: Cache Docker layers
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /tmp/.buildx-cache
         key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -687,8 +682,6 @@ jobs:
 
     - name: Prepare
       id: prep
-      env:
-        DOCKERHUB_REGISTRY_USER: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
       run: |
         set -e
 
@@ -696,25 +689,26 @@ jobs:
         # CI_PROJECT_NAMESPACE=$( echo "${{ github.repository }}" | cut -d '/' -f 1 )
         # CI_PROJECT_NAME=$( echo "${{ github.repository }}" | cut -d '/' -f 2 )
 
-        # Get <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. . E.g. 'master', 'v1.2.3'
+        # Get ref, i.e. <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. 'master' or 'v1.2.3'
         REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+
         # Get commit hash E.g. 'b29758a'
         SHA_SHORT=$( echo "${GITHUB_SHA}" | cut -c1-7 )
 
-        # Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
+        # Generate the final tags. E.g. 'master-mytag' and 'master-b29758a-mytag'
         VARIANT_TAG_WITH_REF="${REF}-${VARIANT_TAG}"
         VARIANT_TAG_WITH_REF_AND_SHA_SHORT="${REF}-${SHA_SHORT}-${VARIANT_TAG}"
 
-        # Set step output(s)
-        # echo "::set-output name=CI_PROJECT_NAMESPACE::$CI_PROJECT_NAMESPACE"
-        # echo "::set-output name=CI_PROJECT_NAME::$CI_PROJECT_NAME"
-        # echo "::set-output name=REF::$REF"
-        # echo "::set-output name=SHA_SHORT::$SHA_SHORT"
-        # echo "::set-output name=REF_AND_SHA_SHORT::$REF_AND_SHA_SHORT"
-        echo "::set-output name=CONTEXT::$VARIANT_BUILD_DIR"
-        echo "::set-output name=VARIANT_TAG::$VARIANT_TAG"
-        echo "::set-output name=VARIANT_TAG_WITH_REF::$VARIANT_TAG_WITH_REF"
-        echo "::set-output name=VARIANT_TAG_WITH_REF_AND_SHA_SHORT::$VARIANT_TAG_WITH_REF_AND_SHA_SHORT"
+        # Pass variables to next step
+        # echo "CI_PROJECT_NAMESPACE=$CI_PROJECT_NAMESPACE" >> $GITHUB_ENV
+        # echo "CI_PROJECT_NAME=$CI_PROJECT_NAME" >> $GITHUB_ENV
+        # echo "REF=$REF" >> $GITHUB_ENV
+        # echo "SHA_SHORT=$SHA_SHORT" >> $GITHUB_ENV
+        # echo "REF_AND_SHA_SHORT=$REF_AND_SHA_SHORT" >> $GITHUB_ENV
+        echo "VARIANT_BUILD_DIR=$VARIANT_BUILD_DIR" >> $GITHUB_ENV
+        echo "VARIANT_TAG=$VARIANT_TAG" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF=$VARIANT_TAG_WITH_REF" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF_AND_SHA_SHORT=$VARIANT_TAG_WITH_REF_AND_SHA_SHORT" >> $GITHUB_ENV
 
     - name: Login to docker registry
       if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
@@ -727,14 +721,14 @@ jobs:
       id: docker_build_pr
       # Run only on pull requests
       if: github.event_name == 'pull_request'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -742,28 +736,28 @@ jobs:
       id: docker_build_master
       # Run only on master
       if: github.ref == 'refs/heads/master'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Build and push (release)
       id: docker_build_release
       if: startsWith(github.ref, 'refs/tags/')
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -781,7 +775,7 @@ jobs:
       VARIANT_BUILD_DIR: variants/v0.12.25-alpine-3.12
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Display system info (linux)
       run: |
@@ -798,14 +792,14 @@ jobs:
 
     # See: https://github.com/docker/build-push-action/blob/v2.6.1/docs/advanced/cache.md#github-cache
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@master
 
     - name: Cache Docker layers
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /tmp/.buildx-cache
         key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -814,8 +808,6 @@ jobs:
 
     - name: Prepare
       id: prep
-      env:
-        DOCKERHUB_REGISTRY_USER: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
       run: |
         set -e
 
@@ -823,25 +815,26 @@ jobs:
         # CI_PROJECT_NAMESPACE=$( echo "${{ github.repository }}" | cut -d '/' -f 1 )
         # CI_PROJECT_NAME=$( echo "${{ github.repository }}" | cut -d '/' -f 2 )
 
-        # Get <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. . E.g. 'master', 'v1.2.3'
+        # Get ref, i.e. <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. 'master' or 'v1.2.3'
         REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+
         # Get commit hash E.g. 'b29758a'
         SHA_SHORT=$( echo "${GITHUB_SHA}" | cut -c1-7 )
 
-        # Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
+        # Generate the final tags. E.g. 'master-mytag' and 'master-b29758a-mytag'
         VARIANT_TAG_WITH_REF="${REF}-${VARIANT_TAG}"
         VARIANT_TAG_WITH_REF_AND_SHA_SHORT="${REF}-${SHA_SHORT}-${VARIANT_TAG}"
 
-        # Set step output(s)
-        # echo "::set-output name=CI_PROJECT_NAMESPACE::$CI_PROJECT_NAMESPACE"
-        # echo "::set-output name=CI_PROJECT_NAME::$CI_PROJECT_NAME"
-        # echo "::set-output name=REF::$REF"
-        # echo "::set-output name=SHA_SHORT::$SHA_SHORT"
-        # echo "::set-output name=REF_AND_SHA_SHORT::$REF_AND_SHA_SHORT"
-        echo "::set-output name=CONTEXT::$VARIANT_BUILD_DIR"
-        echo "::set-output name=VARIANT_TAG::$VARIANT_TAG"
-        echo "::set-output name=VARIANT_TAG_WITH_REF::$VARIANT_TAG_WITH_REF"
-        echo "::set-output name=VARIANT_TAG_WITH_REF_AND_SHA_SHORT::$VARIANT_TAG_WITH_REF_AND_SHA_SHORT"
+        # Pass variables to next step
+        # echo "CI_PROJECT_NAMESPACE=$CI_PROJECT_NAMESPACE" >> $GITHUB_ENV
+        # echo "CI_PROJECT_NAME=$CI_PROJECT_NAME" >> $GITHUB_ENV
+        # echo "REF=$REF" >> $GITHUB_ENV
+        # echo "SHA_SHORT=$SHA_SHORT" >> $GITHUB_ENV
+        # echo "REF_AND_SHA_SHORT=$REF_AND_SHA_SHORT" >> $GITHUB_ENV
+        echo "VARIANT_BUILD_DIR=$VARIANT_BUILD_DIR" >> $GITHUB_ENV
+        echo "VARIANT_TAG=$VARIANT_TAG" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF=$VARIANT_TAG_WITH_REF" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF_AND_SHA_SHORT=$VARIANT_TAG_WITH_REF_AND_SHA_SHORT" >> $GITHUB_ENV
 
     - name: Login to docker registry
       if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
@@ -854,14 +847,14 @@ jobs:
       id: docker_build_pr
       # Run only on pull requests
       if: github.event_name == 'pull_request'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -869,28 +862,28 @@ jobs:
       id: docker_build_master
       # Run only on master
       if: github.ref == 'refs/heads/master'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Build and push (release)
       id: docker_build_release
       if: startsWith(github.ref, 'refs/tags/')
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -908,7 +901,7 @@ jobs:
       VARIANT_BUILD_DIR: variants/v0.12.25-sops-ssh-alpine-3.12
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Display system info (linux)
       run: |
@@ -925,14 +918,14 @@ jobs:
 
     # See: https://github.com/docker/build-push-action/blob/v2.6.1/docs/advanced/cache.md#github-cache
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@master
 
     - name: Cache Docker layers
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /tmp/.buildx-cache
         key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -941,8 +934,6 @@ jobs:
 
     - name: Prepare
       id: prep
-      env:
-        DOCKERHUB_REGISTRY_USER: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
       run: |
         set -e
 
@@ -950,25 +941,26 @@ jobs:
         # CI_PROJECT_NAMESPACE=$( echo "${{ github.repository }}" | cut -d '/' -f 1 )
         # CI_PROJECT_NAME=$( echo "${{ github.repository }}" | cut -d '/' -f 2 )
 
-        # Get <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. . E.g. 'master', 'v1.2.3'
+        # Get ref, i.e. <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. 'master' or 'v1.2.3'
         REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+
         # Get commit hash E.g. 'b29758a'
         SHA_SHORT=$( echo "${GITHUB_SHA}" | cut -c1-7 )
 
-        # Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
+        # Generate the final tags. E.g. 'master-mytag' and 'master-b29758a-mytag'
         VARIANT_TAG_WITH_REF="${REF}-${VARIANT_TAG}"
         VARIANT_TAG_WITH_REF_AND_SHA_SHORT="${REF}-${SHA_SHORT}-${VARIANT_TAG}"
 
-        # Set step output(s)
-        # echo "::set-output name=CI_PROJECT_NAMESPACE::$CI_PROJECT_NAMESPACE"
-        # echo "::set-output name=CI_PROJECT_NAME::$CI_PROJECT_NAME"
-        # echo "::set-output name=REF::$REF"
-        # echo "::set-output name=SHA_SHORT::$SHA_SHORT"
-        # echo "::set-output name=REF_AND_SHA_SHORT::$REF_AND_SHA_SHORT"
-        echo "::set-output name=CONTEXT::$VARIANT_BUILD_DIR"
-        echo "::set-output name=VARIANT_TAG::$VARIANT_TAG"
-        echo "::set-output name=VARIANT_TAG_WITH_REF::$VARIANT_TAG_WITH_REF"
-        echo "::set-output name=VARIANT_TAG_WITH_REF_AND_SHA_SHORT::$VARIANT_TAG_WITH_REF_AND_SHA_SHORT"
+        # Pass variables to next step
+        # echo "CI_PROJECT_NAMESPACE=$CI_PROJECT_NAMESPACE" >> $GITHUB_ENV
+        # echo "CI_PROJECT_NAME=$CI_PROJECT_NAME" >> $GITHUB_ENV
+        # echo "REF=$REF" >> $GITHUB_ENV
+        # echo "SHA_SHORT=$SHA_SHORT" >> $GITHUB_ENV
+        # echo "REF_AND_SHA_SHORT=$REF_AND_SHA_SHORT" >> $GITHUB_ENV
+        echo "VARIANT_BUILD_DIR=$VARIANT_BUILD_DIR" >> $GITHUB_ENV
+        echo "VARIANT_TAG=$VARIANT_TAG" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF=$VARIANT_TAG_WITH_REF" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF_AND_SHA_SHORT=$VARIANT_TAG_WITH_REF_AND_SHA_SHORT" >> $GITHUB_ENV
 
     - name: Login to docker registry
       if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
@@ -981,14 +973,14 @@ jobs:
       id: docker_build_pr
       # Run only on pull requests
       if: github.event_name == 'pull_request'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -996,28 +988,28 @@ jobs:
       id: docker_build_master
       # Run only on master
       if: github.ref == 'refs/heads/master'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Build and push (release)
       id: docker_build_release
       if: startsWith(github.ref, 'refs/tags/')
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -1035,7 +1027,7 @@ jobs:
       VARIANT_BUILD_DIR: variants/v0.12.17-alpine-3.11
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Display system info (linux)
       run: |
@@ -1052,14 +1044,14 @@ jobs:
 
     # See: https://github.com/docker/build-push-action/blob/v2.6.1/docs/advanced/cache.md#github-cache
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@master
 
     - name: Cache Docker layers
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /tmp/.buildx-cache
         key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -1068,8 +1060,6 @@ jobs:
 
     - name: Prepare
       id: prep
-      env:
-        DOCKERHUB_REGISTRY_USER: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
       run: |
         set -e
 
@@ -1077,25 +1067,26 @@ jobs:
         # CI_PROJECT_NAMESPACE=$( echo "${{ github.repository }}" | cut -d '/' -f 1 )
         # CI_PROJECT_NAME=$( echo "${{ github.repository }}" | cut -d '/' -f 2 )
 
-        # Get <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. . E.g. 'master', 'v1.2.3'
+        # Get ref, i.e. <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. 'master' or 'v1.2.3'
         REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+
         # Get commit hash E.g. 'b29758a'
         SHA_SHORT=$( echo "${GITHUB_SHA}" | cut -c1-7 )
 
-        # Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
+        # Generate the final tags. E.g. 'master-mytag' and 'master-b29758a-mytag'
         VARIANT_TAG_WITH_REF="${REF}-${VARIANT_TAG}"
         VARIANT_TAG_WITH_REF_AND_SHA_SHORT="${REF}-${SHA_SHORT}-${VARIANT_TAG}"
 
-        # Set step output(s)
-        # echo "::set-output name=CI_PROJECT_NAMESPACE::$CI_PROJECT_NAMESPACE"
-        # echo "::set-output name=CI_PROJECT_NAME::$CI_PROJECT_NAME"
-        # echo "::set-output name=REF::$REF"
-        # echo "::set-output name=SHA_SHORT::$SHA_SHORT"
-        # echo "::set-output name=REF_AND_SHA_SHORT::$REF_AND_SHA_SHORT"
-        echo "::set-output name=CONTEXT::$VARIANT_BUILD_DIR"
-        echo "::set-output name=VARIANT_TAG::$VARIANT_TAG"
-        echo "::set-output name=VARIANT_TAG_WITH_REF::$VARIANT_TAG_WITH_REF"
-        echo "::set-output name=VARIANT_TAG_WITH_REF_AND_SHA_SHORT::$VARIANT_TAG_WITH_REF_AND_SHA_SHORT"
+        # Pass variables to next step
+        # echo "CI_PROJECT_NAMESPACE=$CI_PROJECT_NAMESPACE" >> $GITHUB_ENV
+        # echo "CI_PROJECT_NAME=$CI_PROJECT_NAME" >> $GITHUB_ENV
+        # echo "REF=$REF" >> $GITHUB_ENV
+        # echo "SHA_SHORT=$SHA_SHORT" >> $GITHUB_ENV
+        # echo "REF_AND_SHA_SHORT=$REF_AND_SHA_SHORT" >> $GITHUB_ENV
+        echo "VARIANT_BUILD_DIR=$VARIANT_BUILD_DIR" >> $GITHUB_ENV
+        echo "VARIANT_TAG=$VARIANT_TAG" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF=$VARIANT_TAG_WITH_REF" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF_AND_SHA_SHORT=$VARIANT_TAG_WITH_REF_AND_SHA_SHORT" >> $GITHUB_ENV
 
     - name: Login to docker registry
       if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
@@ -1108,14 +1099,14 @@ jobs:
       id: docker_build_pr
       # Run only on pull requests
       if: github.event_name == 'pull_request'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -1123,28 +1114,28 @@ jobs:
       id: docker_build_master
       # Run only on master
       if: github.ref == 'refs/heads/master'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Build and push (release)
       id: docker_build_release
       if: startsWith(github.ref, 'refs/tags/')
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -1162,7 +1153,7 @@ jobs:
       VARIANT_BUILD_DIR: variants/v0.12.17-sops-ssh-alpine-3.11
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Display system info (linux)
       run: |
@@ -1179,14 +1170,14 @@ jobs:
 
     # See: https://github.com/docker/build-push-action/blob/v2.6.1/docs/advanced/cache.md#github-cache
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@master
 
     - name: Cache Docker layers
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /tmp/.buildx-cache
         key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -1195,8 +1186,6 @@ jobs:
 
     - name: Prepare
       id: prep
-      env:
-        DOCKERHUB_REGISTRY_USER: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
       run: |
         set -e
 
@@ -1204,25 +1193,26 @@ jobs:
         # CI_PROJECT_NAMESPACE=$( echo "${{ github.repository }}" | cut -d '/' -f 1 )
         # CI_PROJECT_NAME=$( echo "${{ github.repository }}" | cut -d '/' -f 2 )
 
-        # Get <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. . E.g. 'master', 'v1.2.3'
+        # Get ref, i.e. <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. 'master' or 'v1.2.3'
         REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+
         # Get commit hash E.g. 'b29758a'
         SHA_SHORT=$( echo "${GITHUB_SHA}" | cut -c1-7 )
 
-        # Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
+        # Generate the final tags. E.g. 'master-mytag' and 'master-b29758a-mytag'
         VARIANT_TAG_WITH_REF="${REF}-${VARIANT_TAG}"
         VARIANT_TAG_WITH_REF_AND_SHA_SHORT="${REF}-${SHA_SHORT}-${VARIANT_TAG}"
 
-        # Set step output(s)
-        # echo "::set-output name=CI_PROJECT_NAMESPACE::$CI_PROJECT_NAMESPACE"
-        # echo "::set-output name=CI_PROJECT_NAME::$CI_PROJECT_NAME"
-        # echo "::set-output name=REF::$REF"
-        # echo "::set-output name=SHA_SHORT::$SHA_SHORT"
-        # echo "::set-output name=REF_AND_SHA_SHORT::$REF_AND_SHA_SHORT"
-        echo "::set-output name=CONTEXT::$VARIANT_BUILD_DIR"
-        echo "::set-output name=VARIANT_TAG::$VARIANT_TAG"
-        echo "::set-output name=VARIANT_TAG_WITH_REF::$VARIANT_TAG_WITH_REF"
-        echo "::set-output name=VARIANT_TAG_WITH_REF_AND_SHA_SHORT::$VARIANT_TAG_WITH_REF_AND_SHA_SHORT"
+        # Pass variables to next step
+        # echo "CI_PROJECT_NAMESPACE=$CI_PROJECT_NAMESPACE" >> $GITHUB_ENV
+        # echo "CI_PROJECT_NAME=$CI_PROJECT_NAME" >> $GITHUB_ENV
+        # echo "REF=$REF" >> $GITHUB_ENV
+        # echo "SHA_SHORT=$SHA_SHORT" >> $GITHUB_ENV
+        # echo "REF_AND_SHA_SHORT=$REF_AND_SHA_SHORT" >> $GITHUB_ENV
+        echo "VARIANT_BUILD_DIR=$VARIANT_BUILD_DIR" >> $GITHUB_ENV
+        echo "VARIANT_TAG=$VARIANT_TAG" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF=$VARIANT_TAG_WITH_REF" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF_AND_SHA_SHORT=$VARIANT_TAG_WITH_REF_AND_SHA_SHORT" >> $GITHUB_ENV
 
     - name: Login to docker registry
       if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
@@ -1235,14 +1225,14 @@ jobs:
       id: docker_build_pr
       # Run only on pull requests
       if: github.event_name == 'pull_request'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -1250,28 +1240,28 @@ jobs:
       id: docker_build_master
       # Run only on master
       if: github.ref == 'refs/heads/master'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Build and push (release)
       id: docker_build_release
       if: startsWith(github.ref, 'refs/tags/')
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -1289,7 +1279,7 @@ jobs:
       VARIANT_BUILD_DIR: variants/v0.12.6-alpine-3.10
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Display system info (linux)
       run: |
@@ -1306,14 +1296,14 @@ jobs:
 
     # See: https://github.com/docker/build-push-action/blob/v2.6.1/docs/advanced/cache.md#github-cache
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@master
 
     - name: Cache Docker layers
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /tmp/.buildx-cache
         key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -1322,8 +1312,6 @@ jobs:
 
     - name: Prepare
       id: prep
-      env:
-        DOCKERHUB_REGISTRY_USER: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
       run: |
         set -e
 
@@ -1331,25 +1319,26 @@ jobs:
         # CI_PROJECT_NAMESPACE=$( echo "${{ github.repository }}" | cut -d '/' -f 1 )
         # CI_PROJECT_NAME=$( echo "${{ github.repository }}" | cut -d '/' -f 2 )
 
-        # Get <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. . E.g. 'master', 'v1.2.3'
+        # Get ref, i.e. <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. 'master' or 'v1.2.3'
         REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+
         # Get commit hash E.g. 'b29758a'
         SHA_SHORT=$( echo "${GITHUB_SHA}" | cut -c1-7 )
 
-        # Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
+        # Generate the final tags. E.g. 'master-mytag' and 'master-b29758a-mytag'
         VARIANT_TAG_WITH_REF="${REF}-${VARIANT_TAG}"
         VARIANT_TAG_WITH_REF_AND_SHA_SHORT="${REF}-${SHA_SHORT}-${VARIANT_TAG}"
 
-        # Set step output(s)
-        # echo "::set-output name=CI_PROJECT_NAMESPACE::$CI_PROJECT_NAMESPACE"
-        # echo "::set-output name=CI_PROJECT_NAME::$CI_PROJECT_NAME"
-        # echo "::set-output name=REF::$REF"
-        # echo "::set-output name=SHA_SHORT::$SHA_SHORT"
-        # echo "::set-output name=REF_AND_SHA_SHORT::$REF_AND_SHA_SHORT"
-        echo "::set-output name=CONTEXT::$VARIANT_BUILD_DIR"
-        echo "::set-output name=VARIANT_TAG::$VARIANT_TAG"
-        echo "::set-output name=VARIANT_TAG_WITH_REF::$VARIANT_TAG_WITH_REF"
-        echo "::set-output name=VARIANT_TAG_WITH_REF_AND_SHA_SHORT::$VARIANT_TAG_WITH_REF_AND_SHA_SHORT"
+        # Pass variables to next step
+        # echo "CI_PROJECT_NAMESPACE=$CI_PROJECT_NAMESPACE" >> $GITHUB_ENV
+        # echo "CI_PROJECT_NAME=$CI_PROJECT_NAME" >> $GITHUB_ENV
+        # echo "REF=$REF" >> $GITHUB_ENV
+        # echo "SHA_SHORT=$SHA_SHORT" >> $GITHUB_ENV
+        # echo "REF_AND_SHA_SHORT=$REF_AND_SHA_SHORT" >> $GITHUB_ENV
+        echo "VARIANT_BUILD_DIR=$VARIANT_BUILD_DIR" >> $GITHUB_ENV
+        echo "VARIANT_TAG=$VARIANT_TAG" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF=$VARIANT_TAG_WITH_REF" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF_AND_SHA_SHORT=$VARIANT_TAG_WITH_REF_AND_SHA_SHORT" >> $GITHUB_ENV
 
     - name: Login to docker registry
       if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
@@ -1362,14 +1351,14 @@ jobs:
       id: docker_build_pr
       # Run only on pull requests
       if: github.event_name == 'pull_request'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -1377,28 +1366,28 @@ jobs:
       id: docker_build_master
       # Run only on master
       if: github.ref == 'refs/heads/master'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Build and push (release)
       id: docker_build_release
       if: startsWith(github.ref, 'refs/tags/')
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -1416,7 +1405,7 @@ jobs:
       VARIANT_BUILD_DIR: variants/v0.12.6-sops-ssh-alpine-3.10
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Display system info (linux)
       run: |
@@ -1433,14 +1422,14 @@ jobs:
 
     # See: https://github.com/docker/build-push-action/blob/v2.6.1/docs/advanced/cache.md#github-cache
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@master
 
     - name: Cache Docker layers
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /tmp/.buildx-cache
         key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -1449,8 +1438,6 @@ jobs:
 
     - name: Prepare
       id: prep
-      env:
-        DOCKERHUB_REGISTRY_USER: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
       run: |
         set -e
 
@@ -1458,25 +1445,26 @@ jobs:
         # CI_PROJECT_NAMESPACE=$( echo "${{ github.repository }}" | cut -d '/' -f 1 )
         # CI_PROJECT_NAME=$( echo "${{ github.repository }}" | cut -d '/' -f 2 )
 
-        # Get <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. . E.g. 'master', 'v1.2.3'
+        # Get ref, i.e. <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. 'master' or 'v1.2.3'
         REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+
         # Get commit hash E.g. 'b29758a'
         SHA_SHORT=$( echo "${GITHUB_SHA}" | cut -c1-7 )
 
-        # Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
+        # Generate the final tags. E.g. 'master-mytag' and 'master-b29758a-mytag'
         VARIANT_TAG_WITH_REF="${REF}-${VARIANT_TAG}"
         VARIANT_TAG_WITH_REF_AND_SHA_SHORT="${REF}-${SHA_SHORT}-${VARIANT_TAG}"
 
-        # Set step output(s)
-        # echo "::set-output name=CI_PROJECT_NAMESPACE::$CI_PROJECT_NAMESPACE"
-        # echo "::set-output name=CI_PROJECT_NAME::$CI_PROJECT_NAME"
-        # echo "::set-output name=REF::$REF"
-        # echo "::set-output name=SHA_SHORT::$SHA_SHORT"
-        # echo "::set-output name=REF_AND_SHA_SHORT::$REF_AND_SHA_SHORT"
-        echo "::set-output name=CONTEXT::$VARIANT_BUILD_DIR"
-        echo "::set-output name=VARIANT_TAG::$VARIANT_TAG"
-        echo "::set-output name=VARIANT_TAG_WITH_REF::$VARIANT_TAG_WITH_REF"
-        echo "::set-output name=VARIANT_TAG_WITH_REF_AND_SHA_SHORT::$VARIANT_TAG_WITH_REF_AND_SHA_SHORT"
+        # Pass variables to next step
+        # echo "CI_PROJECT_NAMESPACE=$CI_PROJECT_NAMESPACE" >> $GITHUB_ENV
+        # echo "CI_PROJECT_NAME=$CI_PROJECT_NAME" >> $GITHUB_ENV
+        # echo "REF=$REF" >> $GITHUB_ENV
+        # echo "SHA_SHORT=$SHA_SHORT" >> $GITHUB_ENV
+        # echo "REF_AND_SHA_SHORT=$REF_AND_SHA_SHORT" >> $GITHUB_ENV
+        echo "VARIANT_BUILD_DIR=$VARIANT_BUILD_DIR" >> $GITHUB_ENV
+        echo "VARIANT_TAG=$VARIANT_TAG" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF=$VARIANT_TAG_WITH_REF" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF_AND_SHA_SHORT=$VARIANT_TAG_WITH_REF_AND_SHA_SHORT" >> $GITHUB_ENV
 
     - name: Login to docker registry
       if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
@@ -1489,14 +1477,14 @@ jobs:
       id: docker_build_pr
       # Run only on pull requests
       if: github.event_name == 'pull_request'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -1504,28 +1492,28 @@ jobs:
       id: docker_build_master
       # Run only on master
       if: github.ref == 'refs/heads/master'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Build and push (release)
       id: docker_build_release
       if: startsWith(github.ref, 'refs/tags/')
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -1543,7 +1531,7 @@ jobs:
       VARIANT_BUILD_DIR: variants/v0.11.8-alpine-3.9
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Display system info (linux)
       run: |
@@ -1560,14 +1548,14 @@ jobs:
 
     # See: https://github.com/docker/build-push-action/blob/v2.6.1/docs/advanced/cache.md#github-cache
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@master
 
     - name: Cache Docker layers
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /tmp/.buildx-cache
         key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -1576,8 +1564,6 @@ jobs:
 
     - name: Prepare
       id: prep
-      env:
-        DOCKERHUB_REGISTRY_USER: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
       run: |
         set -e
 
@@ -1585,25 +1571,26 @@ jobs:
         # CI_PROJECT_NAMESPACE=$( echo "${{ github.repository }}" | cut -d '/' -f 1 )
         # CI_PROJECT_NAME=$( echo "${{ github.repository }}" | cut -d '/' -f 2 )
 
-        # Get <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. . E.g. 'master', 'v1.2.3'
+        # Get ref, i.e. <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. 'master' or 'v1.2.3'
         REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+
         # Get commit hash E.g. 'b29758a'
         SHA_SHORT=$( echo "${GITHUB_SHA}" | cut -c1-7 )
 
-        # Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
+        # Generate the final tags. E.g. 'master-mytag' and 'master-b29758a-mytag'
         VARIANT_TAG_WITH_REF="${REF}-${VARIANT_TAG}"
         VARIANT_TAG_WITH_REF_AND_SHA_SHORT="${REF}-${SHA_SHORT}-${VARIANT_TAG}"
 
-        # Set step output(s)
-        # echo "::set-output name=CI_PROJECT_NAMESPACE::$CI_PROJECT_NAMESPACE"
-        # echo "::set-output name=CI_PROJECT_NAME::$CI_PROJECT_NAME"
-        # echo "::set-output name=REF::$REF"
-        # echo "::set-output name=SHA_SHORT::$SHA_SHORT"
-        # echo "::set-output name=REF_AND_SHA_SHORT::$REF_AND_SHA_SHORT"
-        echo "::set-output name=CONTEXT::$VARIANT_BUILD_DIR"
-        echo "::set-output name=VARIANT_TAG::$VARIANT_TAG"
-        echo "::set-output name=VARIANT_TAG_WITH_REF::$VARIANT_TAG_WITH_REF"
-        echo "::set-output name=VARIANT_TAG_WITH_REF_AND_SHA_SHORT::$VARIANT_TAG_WITH_REF_AND_SHA_SHORT"
+        # Pass variables to next step
+        # echo "CI_PROJECT_NAMESPACE=$CI_PROJECT_NAMESPACE" >> $GITHUB_ENV
+        # echo "CI_PROJECT_NAME=$CI_PROJECT_NAME" >> $GITHUB_ENV
+        # echo "REF=$REF" >> $GITHUB_ENV
+        # echo "SHA_SHORT=$SHA_SHORT" >> $GITHUB_ENV
+        # echo "REF_AND_SHA_SHORT=$REF_AND_SHA_SHORT" >> $GITHUB_ENV
+        echo "VARIANT_BUILD_DIR=$VARIANT_BUILD_DIR" >> $GITHUB_ENV
+        echo "VARIANT_TAG=$VARIANT_TAG" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF=$VARIANT_TAG_WITH_REF" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF_AND_SHA_SHORT=$VARIANT_TAG_WITH_REF_AND_SHA_SHORT" >> $GITHUB_ENV
 
     - name: Login to docker registry
       if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
@@ -1616,14 +1603,14 @@ jobs:
       id: docker_build_pr
       # Run only on pull requests
       if: github.event_name == 'pull_request'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -1631,28 +1618,28 @@ jobs:
       id: docker_build_master
       # Run only on master
       if: github.ref == 'refs/heads/master'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Build and push (release)
       id: docker_build_release
       if: startsWith(github.ref, 'refs/tags/')
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -1670,7 +1657,7 @@ jobs:
       VARIANT_BUILD_DIR: variants/v0.11.8-sops-ssh-alpine-3.9
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Display system info (linux)
       run: |
@@ -1687,14 +1674,14 @@ jobs:
 
     # See: https://github.com/docker/build-push-action/blob/v2.6.1/docs/advanced/cache.md#github-cache
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@master
 
     - name: Cache Docker layers
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /tmp/.buildx-cache
         key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -1703,8 +1690,6 @@ jobs:
 
     - name: Prepare
       id: prep
-      env:
-        DOCKERHUB_REGISTRY_USER: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
       run: |
         set -e
 
@@ -1712,25 +1697,26 @@ jobs:
         # CI_PROJECT_NAMESPACE=$( echo "${{ github.repository }}" | cut -d '/' -f 1 )
         # CI_PROJECT_NAME=$( echo "${{ github.repository }}" | cut -d '/' -f 2 )
 
-        # Get <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. . E.g. 'master', 'v1.2.3'
+        # Get ref, i.e. <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. 'master' or 'v1.2.3'
         REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+
         # Get commit hash E.g. 'b29758a'
         SHA_SHORT=$( echo "${GITHUB_SHA}" | cut -c1-7 )
 
-        # Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
+        # Generate the final tags. E.g. 'master-mytag' and 'master-b29758a-mytag'
         VARIANT_TAG_WITH_REF="${REF}-${VARIANT_TAG}"
         VARIANT_TAG_WITH_REF_AND_SHA_SHORT="${REF}-${SHA_SHORT}-${VARIANT_TAG}"
 
-        # Set step output(s)
-        # echo "::set-output name=CI_PROJECT_NAMESPACE::$CI_PROJECT_NAMESPACE"
-        # echo "::set-output name=CI_PROJECT_NAME::$CI_PROJECT_NAME"
-        # echo "::set-output name=REF::$REF"
-        # echo "::set-output name=SHA_SHORT::$SHA_SHORT"
-        # echo "::set-output name=REF_AND_SHA_SHORT::$REF_AND_SHA_SHORT"
-        echo "::set-output name=CONTEXT::$VARIANT_BUILD_DIR"
-        echo "::set-output name=VARIANT_TAG::$VARIANT_TAG"
-        echo "::set-output name=VARIANT_TAG_WITH_REF::$VARIANT_TAG_WITH_REF"
-        echo "::set-output name=VARIANT_TAG_WITH_REF_AND_SHA_SHORT::$VARIANT_TAG_WITH_REF_AND_SHA_SHORT"
+        # Pass variables to next step
+        # echo "CI_PROJECT_NAMESPACE=$CI_PROJECT_NAMESPACE" >> $GITHUB_ENV
+        # echo "CI_PROJECT_NAME=$CI_PROJECT_NAME" >> $GITHUB_ENV
+        # echo "REF=$REF" >> $GITHUB_ENV
+        # echo "SHA_SHORT=$SHA_SHORT" >> $GITHUB_ENV
+        # echo "REF_AND_SHA_SHORT=$REF_AND_SHA_SHORT" >> $GITHUB_ENV
+        echo "VARIANT_BUILD_DIR=$VARIANT_BUILD_DIR" >> $GITHUB_ENV
+        echo "VARIANT_TAG=$VARIANT_TAG" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF=$VARIANT_TAG_WITH_REF" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF_AND_SHA_SHORT=$VARIANT_TAG_WITH_REF_AND_SHA_SHORT" >> $GITHUB_ENV
 
     - name: Login to docker registry
       if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
@@ -1743,14 +1729,14 @@ jobs:
       id: docker_build_pr
       # Run only on pull requests
       if: github.event_name == 'pull_request'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -1758,28 +1744,28 @@ jobs:
       id: docker_build_master
       # Run only on master
       if: github.ref == 'refs/heads/master'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Build and push (release)
       id: docker_build_release
       if: startsWith(github.ref, 'refs/tags/')
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -1797,7 +1783,7 @@ jobs:
       VARIANT_BUILD_DIR: variants/v0.11.7-alpine-3.8
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Display system info (linux)
       run: |
@@ -1814,14 +1800,14 @@ jobs:
 
     # See: https://github.com/docker/build-push-action/blob/v2.6.1/docs/advanced/cache.md#github-cache
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@master
 
     - name: Cache Docker layers
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /tmp/.buildx-cache
         key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -1830,8 +1816,6 @@ jobs:
 
     - name: Prepare
       id: prep
-      env:
-        DOCKERHUB_REGISTRY_USER: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
       run: |
         set -e
 
@@ -1839,25 +1823,26 @@ jobs:
         # CI_PROJECT_NAMESPACE=$( echo "${{ github.repository }}" | cut -d '/' -f 1 )
         # CI_PROJECT_NAME=$( echo "${{ github.repository }}" | cut -d '/' -f 2 )
 
-        # Get <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. . E.g. 'master', 'v1.2.3'
+        # Get ref, i.e. <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. 'master' or 'v1.2.3'
         REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+
         # Get commit hash E.g. 'b29758a'
         SHA_SHORT=$( echo "${GITHUB_SHA}" | cut -c1-7 )
 
-        # Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
+        # Generate the final tags. E.g. 'master-mytag' and 'master-b29758a-mytag'
         VARIANT_TAG_WITH_REF="${REF}-${VARIANT_TAG}"
         VARIANT_TAG_WITH_REF_AND_SHA_SHORT="${REF}-${SHA_SHORT}-${VARIANT_TAG}"
 
-        # Set step output(s)
-        # echo "::set-output name=CI_PROJECT_NAMESPACE::$CI_PROJECT_NAMESPACE"
-        # echo "::set-output name=CI_PROJECT_NAME::$CI_PROJECT_NAME"
-        # echo "::set-output name=REF::$REF"
-        # echo "::set-output name=SHA_SHORT::$SHA_SHORT"
-        # echo "::set-output name=REF_AND_SHA_SHORT::$REF_AND_SHA_SHORT"
-        echo "::set-output name=CONTEXT::$VARIANT_BUILD_DIR"
-        echo "::set-output name=VARIANT_TAG::$VARIANT_TAG"
-        echo "::set-output name=VARIANT_TAG_WITH_REF::$VARIANT_TAG_WITH_REF"
-        echo "::set-output name=VARIANT_TAG_WITH_REF_AND_SHA_SHORT::$VARIANT_TAG_WITH_REF_AND_SHA_SHORT"
+        # Pass variables to next step
+        # echo "CI_PROJECT_NAMESPACE=$CI_PROJECT_NAMESPACE" >> $GITHUB_ENV
+        # echo "CI_PROJECT_NAME=$CI_PROJECT_NAME" >> $GITHUB_ENV
+        # echo "REF=$REF" >> $GITHUB_ENV
+        # echo "SHA_SHORT=$SHA_SHORT" >> $GITHUB_ENV
+        # echo "REF_AND_SHA_SHORT=$REF_AND_SHA_SHORT" >> $GITHUB_ENV
+        echo "VARIANT_BUILD_DIR=$VARIANT_BUILD_DIR" >> $GITHUB_ENV
+        echo "VARIANT_TAG=$VARIANT_TAG" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF=$VARIANT_TAG_WITH_REF" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF_AND_SHA_SHORT=$VARIANT_TAG_WITH_REF_AND_SHA_SHORT" >> $GITHUB_ENV
 
     - name: Login to docker registry
       if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
@@ -1870,14 +1855,14 @@ jobs:
       id: docker_build_pr
       # Run only on pull requests
       if: github.event_name == 'pull_request'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -1885,28 +1870,28 @@ jobs:
       id: docker_build_master
       # Run only on master
       if: github.ref == 'refs/heads/master'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Build and push (release)
       id: docker_build_release
       if: startsWith(github.ref, 'refs/tags/')
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -1924,7 +1909,7 @@ jobs:
       VARIANT_BUILD_DIR: variants/v0.11.7-sops-ssh-alpine-3.8
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Display system info (linux)
       run: |
@@ -1941,14 +1926,14 @@ jobs:
 
     # See: https://github.com/docker/build-push-action/blob/v2.6.1/docs/advanced/cache.md#github-cache
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@master
 
     - name: Cache Docker layers
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /tmp/.buildx-cache
         key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -1957,8 +1942,6 @@ jobs:
 
     - name: Prepare
       id: prep
-      env:
-        DOCKERHUB_REGISTRY_USER: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
       run: |
         set -e
 
@@ -1966,25 +1949,26 @@ jobs:
         # CI_PROJECT_NAMESPACE=$( echo "${{ github.repository }}" | cut -d '/' -f 1 )
         # CI_PROJECT_NAME=$( echo "${{ github.repository }}" | cut -d '/' -f 2 )
 
-        # Get <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. . E.g. 'master', 'v1.2.3'
+        # Get ref, i.e. <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. 'master' or 'v1.2.3'
         REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+
         # Get commit hash E.g. 'b29758a'
         SHA_SHORT=$( echo "${GITHUB_SHA}" | cut -c1-7 )
 
-        # Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
+        # Generate the final tags. E.g. 'master-mytag' and 'master-b29758a-mytag'
         VARIANT_TAG_WITH_REF="${REF}-${VARIANT_TAG}"
         VARIANT_TAG_WITH_REF_AND_SHA_SHORT="${REF}-${SHA_SHORT}-${VARIANT_TAG}"
 
-        # Set step output(s)
-        # echo "::set-output name=CI_PROJECT_NAMESPACE::$CI_PROJECT_NAMESPACE"
-        # echo "::set-output name=CI_PROJECT_NAME::$CI_PROJECT_NAME"
-        # echo "::set-output name=REF::$REF"
-        # echo "::set-output name=SHA_SHORT::$SHA_SHORT"
-        # echo "::set-output name=REF_AND_SHA_SHORT::$REF_AND_SHA_SHORT"
-        echo "::set-output name=CONTEXT::$VARIANT_BUILD_DIR"
-        echo "::set-output name=VARIANT_TAG::$VARIANT_TAG"
-        echo "::set-output name=VARIANT_TAG_WITH_REF::$VARIANT_TAG_WITH_REF"
-        echo "::set-output name=VARIANT_TAG_WITH_REF_AND_SHA_SHORT::$VARIANT_TAG_WITH_REF_AND_SHA_SHORT"
+        # Pass variables to next step
+        # echo "CI_PROJECT_NAMESPACE=$CI_PROJECT_NAMESPACE" >> $GITHUB_ENV
+        # echo "CI_PROJECT_NAME=$CI_PROJECT_NAME" >> $GITHUB_ENV
+        # echo "REF=$REF" >> $GITHUB_ENV
+        # echo "SHA_SHORT=$SHA_SHORT" >> $GITHUB_ENV
+        # echo "REF_AND_SHA_SHORT=$REF_AND_SHA_SHORT" >> $GITHUB_ENV
+        echo "VARIANT_BUILD_DIR=$VARIANT_BUILD_DIR" >> $GITHUB_ENV
+        echo "VARIANT_TAG=$VARIANT_TAG" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF=$VARIANT_TAG_WITH_REF" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF_AND_SHA_SHORT=$VARIANT_TAG_WITH_REF_AND_SHA_SHORT" >> $GITHUB_ENV
 
     - name: Login to docker registry
       if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
@@ -1997,14 +1981,14 @@ jobs:
       id: docker_build_pr
       # Run only on pull requests
       if: github.event_name == 'pull_request'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -2012,28 +1996,28 @@ jobs:
       id: docker_build_master
       # Run only on master
       if: github.ref == 'refs/heads/master'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Build and push (release)
       id: docker_build_release
       if: startsWith(github.ref, 'refs/tags/')
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -2051,7 +2035,7 @@ jobs:
       VARIANT_BUILD_DIR: variants/v0.11.0-alpine-3.7
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Display system info (linux)
       run: |
@@ -2068,14 +2052,14 @@ jobs:
 
     # See: https://github.com/docker/build-push-action/blob/v2.6.1/docs/advanced/cache.md#github-cache
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@master
 
     - name: Cache Docker layers
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /tmp/.buildx-cache
         key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -2084,8 +2068,6 @@ jobs:
 
     - name: Prepare
       id: prep
-      env:
-        DOCKERHUB_REGISTRY_USER: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
       run: |
         set -e
 
@@ -2093,25 +2075,26 @@ jobs:
         # CI_PROJECT_NAMESPACE=$( echo "${{ github.repository }}" | cut -d '/' -f 1 )
         # CI_PROJECT_NAME=$( echo "${{ github.repository }}" | cut -d '/' -f 2 )
 
-        # Get <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. . E.g. 'master', 'v1.2.3'
+        # Get ref, i.e. <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. 'master' or 'v1.2.3'
         REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+
         # Get commit hash E.g. 'b29758a'
         SHA_SHORT=$( echo "${GITHUB_SHA}" | cut -c1-7 )
 
-        # Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
+        # Generate the final tags. E.g. 'master-mytag' and 'master-b29758a-mytag'
         VARIANT_TAG_WITH_REF="${REF}-${VARIANT_TAG}"
         VARIANT_TAG_WITH_REF_AND_SHA_SHORT="${REF}-${SHA_SHORT}-${VARIANT_TAG}"
 
-        # Set step output(s)
-        # echo "::set-output name=CI_PROJECT_NAMESPACE::$CI_PROJECT_NAMESPACE"
-        # echo "::set-output name=CI_PROJECT_NAME::$CI_PROJECT_NAME"
-        # echo "::set-output name=REF::$REF"
-        # echo "::set-output name=SHA_SHORT::$SHA_SHORT"
-        # echo "::set-output name=REF_AND_SHA_SHORT::$REF_AND_SHA_SHORT"
-        echo "::set-output name=CONTEXT::$VARIANT_BUILD_DIR"
-        echo "::set-output name=VARIANT_TAG::$VARIANT_TAG"
-        echo "::set-output name=VARIANT_TAG_WITH_REF::$VARIANT_TAG_WITH_REF"
-        echo "::set-output name=VARIANT_TAG_WITH_REF_AND_SHA_SHORT::$VARIANT_TAG_WITH_REF_AND_SHA_SHORT"
+        # Pass variables to next step
+        # echo "CI_PROJECT_NAMESPACE=$CI_PROJECT_NAMESPACE" >> $GITHUB_ENV
+        # echo "CI_PROJECT_NAME=$CI_PROJECT_NAME" >> $GITHUB_ENV
+        # echo "REF=$REF" >> $GITHUB_ENV
+        # echo "SHA_SHORT=$SHA_SHORT" >> $GITHUB_ENV
+        # echo "REF_AND_SHA_SHORT=$REF_AND_SHA_SHORT" >> $GITHUB_ENV
+        echo "VARIANT_BUILD_DIR=$VARIANT_BUILD_DIR" >> $GITHUB_ENV
+        echo "VARIANT_TAG=$VARIANT_TAG" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF=$VARIANT_TAG_WITH_REF" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF_AND_SHA_SHORT=$VARIANT_TAG_WITH_REF_AND_SHA_SHORT" >> $GITHUB_ENV
 
     - name: Login to docker registry
       if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
@@ -2124,14 +2107,14 @@ jobs:
       id: docker_build_pr
       # Run only on pull requests
       if: github.event_name == 'pull_request'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -2139,28 +2122,28 @@ jobs:
       id: docker_build_master
       # Run only on master
       if: github.ref == 'refs/heads/master'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Build and push (release)
       id: docker_build_release
       if: startsWith(github.ref, 'refs/tags/')
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -2178,7 +2161,7 @@ jobs:
       VARIANT_BUILD_DIR: variants/v0.11.0-sops-ssh-alpine-3.7
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Display system info (linux)
       run: |
@@ -2195,14 +2178,14 @@ jobs:
 
     # See: https://github.com/docker/build-push-action/blob/v2.6.1/docs/advanced/cache.md#github-cache
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@master
 
     - name: Cache Docker layers
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /tmp/.buildx-cache
         key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -2211,8 +2194,6 @@ jobs:
 
     - name: Prepare
       id: prep
-      env:
-        DOCKERHUB_REGISTRY_USER: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
       run: |
         set -e
 
@@ -2220,25 +2201,26 @@ jobs:
         # CI_PROJECT_NAMESPACE=$( echo "${{ github.repository }}" | cut -d '/' -f 1 )
         # CI_PROJECT_NAME=$( echo "${{ github.repository }}" | cut -d '/' -f 2 )
 
-        # Get <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. . E.g. 'master', 'v1.2.3'
+        # Get ref, i.e. <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. 'master' or 'v1.2.3'
         REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+
         # Get commit hash E.g. 'b29758a'
         SHA_SHORT=$( echo "${GITHUB_SHA}" | cut -c1-7 )
 
-        # Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
+        # Generate the final tags. E.g. 'master-mytag' and 'master-b29758a-mytag'
         VARIANT_TAG_WITH_REF="${REF}-${VARIANT_TAG}"
         VARIANT_TAG_WITH_REF_AND_SHA_SHORT="${REF}-${SHA_SHORT}-${VARIANT_TAG}"
 
-        # Set step output(s)
-        # echo "::set-output name=CI_PROJECT_NAMESPACE::$CI_PROJECT_NAMESPACE"
-        # echo "::set-output name=CI_PROJECT_NAME::$CI_PROJECT_NAME"
-        # echo "::set-output name=REF::$REF"
-        # echo "::set-output name=SHA_SHORT::$SHA_SHORT"
-        # echo "::set-output name=REF_AND_SHA_SHORT::$REF_AND_SHA_SHORT"
-        echo "::set-output name=CONTEXT::$VARIANT_BUILD_DIR"
-        echo "::set-output name=VARIANT_TAG::$VARIANT_TAG"
-        echo "::set-output name=VARIANT_TAG_WITH_REF::$VARIANT_TAG_WITH_REF"
-        echo "::set-output name=VARIANT_TAG_WITH_REF_AND_SHA_SHORT::$VARIANT_TAG_WITH_REF_AND_SHA_SHORT"
+        # Pass variables to next step
+        # echo "CI_PROJECT_NAMESPACE=$CI_PROJECT_NAMESPACE" >> $GITHUB_ENV
+        # echo "CI_PROJECT_NAME=$CI_PROJECT_NAME" >> $GITHUB_ENV
+        # echo "REF=$REF" >> $GITHUB_ENV
+        # echo "SHA_SHORT=$SHA_SHORT" >> $GITHUB_ENV
+        # echo "REF_AND_SHA_SHORT=$REF_AND_SHA_SHORT" >> $GITHUB_ENV
+        echo "VARIANT_BUILD_DIR=$VARIANT_BUILD_DIR" >> $GITHUB_ENV
+        echo "VARIANT_TAG=$VARIANT_TAG" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF=$VARIANT_TAG_WITH_REF" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF_AND_SHA_SHORT=$VARIANT_TAG_WITH_REF_AND_SHA_SHORT" >> $GITHUB_ENV
 
     - name: Login to docker registry
       if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
@@ -2251,14 +2233,14 @@ jobs:
       id: docker_build_pr
       # Run only on pull requests
       if: github.event_name == 'pull_request'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -2266,28 +2248,28 @@ jobs:
       id: docker_build_master
       # Run only on master
       if: github.ref == 'refs/heads/master'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Build and push (release)
       id: docker_build_release
       if: startsWith(github.ref, 'refs/tags/')
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -2305,7 +2287,7 @@ jobs:
       VARIANT_BUILD_DIR: variants/v0.9.5-alpine-3.6
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Display system info (linux)
       run: |
@@ -2322,14 +2304,14 @@ jobs:
 
     # See: https://github.com/docker/build-push-action/blob/v2.6.1/docs/advanced/cache.md#github-cache
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@master
 
     - name: Cache Docker layers
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /tmp/.buildx-cache
         key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -2338,8 +2320,6 @@ jobs:
 
     - name: Prepare
       id: prep
-      env:
-        DOCKERHUB_REGISTRY_USER: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
       run: |
         set -e
 
@@ -2347,25 +2327,26 @@ jobs:
         # CI_PROJECT_NAMESPACE=$( echo "${{ github.repository }}" | cut -d '/' -f 1 )
         # CI_PROJECT_NAME=$( echo "${{ github.repository }}" | cut -d '/' -f 2 )
 
-        # Get <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. . E.g. 'master', 'v1.2.3'
+        # Get ref, i.e. <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. 'master' or 'v1.2.3'
         REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+
         # Get commit hash E.g. 'b29758a'
         SHA_SHORT=$( echo "${GITHUB_SHA}" | cut -c1-7 )
 
-        # Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
+        # Generate the final tags. E.g. 'master-mytag' and 'master-b29758a-mytag'
         VARIANT_TAG_WITH_REF="${REF}-${VARIANT_TAG}"
         VARIANT_TAG_WITH_REF_AND_SHA_SHORT="${REF}-${SHA_SHORT}-${VARIANT_TAG}"
 
-        # Set step output(s)
-        # echo "::set-output name=CI_PROJECT_NAMESPACE::$CI_PROJECT_NAMESPACE"
-        # echo "::set-output name=CI_PROJECT_NAME::$CI_PROJECT_NAME"
-        # echo "::set-output name=REF::$REF"
-        # echo "::set-output name=SHA_SHORT::$SHA_SHORT"
-        # echo "::set-output name=REF_AND_SHA_SHORT::$REF_AND_SHA_SHORT"
-        echo "::set-output name=CONTEXT::$VARIANT_BUILD_DIR"
-        echo "::set-output name=VARIANT_TAG::$VARIANT_TAG"
-        echo "::set-output name=VARIANT_TAG_WITH_REF::$VARIANT_TAG_WITH_REF"
-        echo "::set-output name=VARIANT_TAG_WITH_REF_AND_SHA_SHORT::$VARIANT_TAG_WITH_REF_AND_SHA_SHORT"
+        # Pass variables to next step
+        # echo "CI_PROJECT_NAMESPACE=$CI_PROJECT_NAMESPACE" >> $GITHUB_ENV
+        # echo "CI_PROJECT_NAME=$CI_PROJECT_NAME" >> $GITHUB_ENV
+        # echo "REF=$REF" >> $GITHUB_ENV
+        # echo "SHA_SHORT=$SHA_SHORT" >> $GITHUB_ENV
+        # echo "REF_AND_SHA_SHORT=$REF_AND_SHA_SHORT" >> $GITHUB_ENV
+        echo "VARIANT_BUILD_DIR=$VARIANT_BUILD_DIR" >> $GITHUB_ENV
+        echo "VARIANT_TAG=$VARIANT_TAG" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF=$VARIANT_TAG_WITH_REF" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF_AND_SHA_SHORT=$VARIANT_TAG_WITH_REF_AND_SHA_SHORT" >> $GITHUB_ENV
 
     - name: Login to docker registry
       if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
@@ -2378,14 +2359,14 @@ jobs:
       id: docker_build_pr
       # Run only on pull requests
       if: github.event_name == 'pull_request'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -2393,28 +2374,28 @@ jobs:
       id: docker_build_master
       # Run only on master
       if: github.ref == 'refs/heads/master'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Build and push (release)
       id: docker_build_release
       if: startsWith(github.ref, 'refs/tags/')
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -2432,7 +2413,7 @@ jobs:
       VARIANT_BUILD_DIR: variants/v0.9.5-sops-ssh-alpine-3.6
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Display system info (linux)
       run: |
@@ -2449,14 +2430,14 @@ jobs:
 
     # See: https://github.com/docker/build-push-action/blob/v2.6.1/docs/advanced/cache.md#github-cache
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@master
 
     - name: Cache Docker layers
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /tmp/.buildx-cache
         key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -2465,8 +2446,6 @@ jobs:
 
     - name: Prepare
       id: prep
-      env:
-        DOCKERHUB_REGISTRY_USER: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
       run: |
         set -e
 
@@ -2474,25 +2453,26 @@ jobs:
         # CI_PROJECT_NAMESPACE=$( echo "${{ github.repository }}" | cut -d '/' -f 1 )
         # CI_PROJECT_NAME=$( echo "${{ github.repository }}" | cut -d '/' -f 2 )
 
-        # Get <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. . E.g. 'master', 'v1.2.3'
+        # Get ref, i.e. <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. 'master' or 'v1.2.3'
         REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+
         # Get commit hash E.g. 'b29758a'
         SHA_SHORT=$( echo "${GITHUB_SHA}" | cut -c1-7 )
 
-        # Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
+        # Generate the final tags. E.g. 'master-mytag' and 'master-b29758a-mytag'
         VARIANT_TAG_WITH_REF="${REF}-${VARIANT_TAG}"
         VARIANT_TAG_WITH_REF_AND_SHA_SHORT="${REF}-${SHA_SHORT}-${VARIANT_TAG}"
 
-        # Set step output(s)
-        # echo "::set-output name=CI_PROJECT_NAMESPACE::$CI_PROJECT_NAMESPACE"
-        # echo "::set-output name=CI_PROJECT_NAME::$CI_PROJECT_NAME"
-        # echo "::set-output name=REF::$REF"
-        # echo "::set-output name=SHA_SHORT::$SHA_SHORT"
-        # echo "::set-output name=REF_AND_SHA_SHORT::$REF_AND_SHA_SHORT"
-        echo "::set-output name=CONTEXT::$VARIANT_BUILD_DIR"
-        echo "::set-output name=VARIANT_TAG::$VARIANT_TAG"
-        echo "::set-output name=VARIANT_TAG_WITH_REF::$VARIANT_TAG_WITH_REF"
-        echo "::set-output name=VARIANT_TAG_WITH_REF_AND_SHA_SHORT::$VARIANT_TAG_WITH_REF_AND_SHA_SHORT"
+        # Pass variables to next step
+        # echo "CI_PROJECT_NAMESPACE=$CI_PROJECT_NAMESPACE" >> $GITHUB_ENV
+        # echo "CI_PROJECT_NAME=$CI_PROJECT_NAME" >> $GITHUB_ENV
+        # echo "REF=$REF" >> $GITHUB_ENV
+        # echo "SHA_SHORT=$SHA_SHORT" >> $GITHUB_ENV
+        # echo "REF_AND_SHA_SHORT=$REF_AND_SHA_SHORT" >> $GITHUB_ENV
+        echo "VARIANT_BUILD_DIR=$VARIANT_BUILD_DIR" >> $GITHUB_ENV
+        echo "VARIANT_TAG=$VARIANT_TAG" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF=$VARIANT_TAG_WITH_REF" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF_AND_SHA_SHORT=$VARIANT_TAG_WITH_REF_AND_SHA_SHORT" >> $GITHUB_ENV
 
     - name: Login to docker registry
       if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
@@ -2505,14 +2485,14 @@ jobs:
       id: docker_build_pr
       # Run only on pull requests
       if: github.event_name == 'pull_request'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -2520,28 +2500,28 @@ jobs:
       id: docker_build_master
       # Run only on master
       if: github.ref == 'refs/heads/master'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Build and push (release)
       id: docker_build_release
       if: startsWith(github.ref, 'refs/tags/')
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -2559,7 +2539,7 @@ jobs:
       VARIANT_BUILD_DIR: variants/v0.8.1-alpine-3.5
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Display system info (linux)
       run: |
@@ -2576,14 +2556,14 @@ jobs:
 
     # See: https://github.com/docker/build-push-action/blob/v2.6.1/docs/advanced/cache.md#github-cache
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@master
 
     - name: Cache Docker layers
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /tmp/.buildx-cache
         key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -2592,8 +2572,6 @@ jobs:
 
     - name: Prepare
       id: prep
-      env:
-        DOCKERHUB_REGISTRY_USER: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
       run: |
         set -e
 
@@ -2601,25 +2579,26 @@ jobs:
         # CI_PROJECT_NAMESPACE=$( echo "${{ github.repository }}" | cut -d '/' -f 1 )
         # CI_PROJECT_NAME=$( echo "${{ github.repository }}" | cut -d '/' -f 2 )
 
-        # Get <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. . E.g. 'master', 'v1.2.3'
+        # Get ref, i.e. <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. 'master' or 'v1.2.3'
         REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+
         # Get commit hash E.g. 'b29758a'
         SHA_SHORT=$( echo "${GITHUB_SHA}" | cut -c1-7 )
 
-        # Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
+        # Generate the final tags. E.g. 'master-mytag' and 'master-b29758a-mytag'
         VARIANT_TAG_WITH_REF="${REF}-${VARIANT_TAG}"
         VARIANT_TAG_WITH_REF_AND_SHA_SHORT="${REF}-${SHA_SHORT}-${VARIANT_TAG}"
 
-        # Set step output(s)
-        # echo "::set-output name=CI_PROJECT_NAMESPACE::$CI_PROJECT_NAMESPACE"
-        # echo "::set-output name=CI_PROJECT_NAME::$CI_PROJECT_NAME"
-        # echo "::set-output name=REF::$REF"
-        # echo "::set-output name=SHA_SHORT::$SHA_SHORT"
-        # echo "::set-output name=REF_AND_SHA_SHORT::$REF_AND_SHA_SHORT"
-        echo "::set-output name=CONTEXT::$VARIANT_BUILD_DIR"
-        echo "::set-output name=VARIANT_TAG::$VARIANT_TAG"
-        echo "::set-output name=VARIANT_TAG_WITH_REF::$VARIANT_TAG_WITH_REF"
-        echo "::set-output name=VARIANT_TAG_WITH_REF_AND_SHA_SHORT::$VARIANT_TAG_WITH_REF_AND_SHA_SHORT"
+        # Pass variables to next step
+        # echo "CI_PROJECT_NAMESPACE=$CI_PROJECT_NAMESPACE" >> $GITHUB_ENV
+        # echo "CI_PROJECT_NAME=$CI_PROJECT_NAME" >> $GITHUB_ENV
+        # echo "REF=$REF" >> $GITHUB_ENV
+        # echo "SHA_SHORT=$SHA_SHORT" >> $GITHUB_ENV
+        # echo "REF_AND_SHA_SHORT=$REF_AND_SHA_SHORT" >> $GITHUB_ENV
+        echo "VARIANT_BUILD_DIR=$VARIANT_BUILD_DIR" >> $GITHUB_ENV
+        echo "VARIANT_TAG=$VARIANT_TAG" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF=$VARIANT_TAG_WITH_REF" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF_AND_SHA_SHORT=$VARIANT_TAG_WITH_REF_AND_SHA_SHORT" >> $GITHUB_ENV
 
     - name: Login to docker registry
       if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
@@ -2632,14 +2611,14 @@ jobs:
       id: docker_build_pr
       # Run only on pull requests
       if: github.event_name == 'pull_request'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -2647,28 +2626,28 @@ jobs:
       id: docker_build_master
       # Run only on master
       if: github.ref == 'refs/heads/master'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Build and push (release)
       id: docker_build_release
       if: startsWith(github.ref, 'refs/tags/')
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -2686,7 +2665,7 @@ jobs:
       VARIANT_BUILD_DIR: variants/v0.8.1-sops-ssh-alpine-3.5
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Display system info (linux)
       run: |
@@ -2703,14 +2682,14 @@ jobs:
 
     # See: https://github.com/docker/build-push-action/blob/v2.6.1/docs/advanced/cache.md#github-cache
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@master
 
     - name: Cache Docker layers
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /tmp/.buildx-cache
         key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -2719,8 +2698,6 @@ jobs:
 
     - name: Prepare
       id: prep
-      env:
-        DOCKERHUB_REGISTRY_USER: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
       run: |
         set -e
 
@@ -2728,25 +2705,26 @@ jobs:
         # CI_PROJECT_NAMESPACE=$( echo "${{ github.repository }}" | cut -d '/' -f 1 )
         # CI_PROJECT_NAME=$( echo "${{ github.repository }}" | cut -d '/' -f 2 )
 
-        # Get <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. . E.g. 'master', 'v1.2.3'
+        # Get ref, i.e. <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. 'master' or 'v1.2.3'
         REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+
         # Get commit hash E.g. 'b29758a'
         SHA_SHORT=$( echo "${GITHUB_SHA}" | cut -c1-7 )
 
-        # Generate the final tags. E.g. 'master-v1.0.0-alpine' and 'master-b29758a-v1.0.0-alpine'
+        # Generate the final tags. E.g. 'master-mytag' and 'master-b29758a-mytag'
         VARIANT_TAG_WITH_REF="${REF}-${VARIANT_TAG}"
         VARIANT_TAG_WITH_REF_AND_SHA_SHORT="${REF}-${SHA_SHORT}-${VARIANT_TAG}"
 
-        # Set step output(s)
-        # echo "::set-output name=CI_PROJECT_NAMESPACE::$CI_PROJECT_NAMESPACE"
-        # echo "::set-output name=CI_PROJECT_NAME::$CI_PROJECT_NAME"
-        # echo "::set-output name=REF::$REF"
-        # echo "::set-output name=SHA_SHORT::$SHA_SHORT"
-        # echo "::set-output name=REF_AND_SHA_SHORT::$REF_AND_SHA_SHORT"
-        echo "::set-output name=CONTEXT::$VARIANT_BUILD_DIR"
-        echo "::set-output name=VARIANT_TAG::$VARIANT_TAG"
-        echo "::set-output name=VARIANT_TAG_WITH_REF::$VARIANT_TAG_WITH_REF"
-        echo "::set-output name=VARIANT_TAG_WITH_REF_AND_SHA_SHORT::$VARIANT_TAG_WITH_REF_AND_SHA_SHORT"
+        # Pass variables to next step
+        # echo "CI_PROJECT_NAMESPACE=$CI_PROJECT_NAMESPACE" >> $GITHUB_ENV
+        # echo "CI_PROJECT_NAME=$CI_PROJECT_NAME" >> $GITHUB_ENV
+        # echo "REF=$REF" >> $GITHUB_ENV
+        # echo "SHA_SHORT=$SHA_SHORT" >> $GITHUB_ENV
+        # echo "REF_AND_SHA_SHORT=$REF_AND_SHA_SHORT" >> $GITHUB_ENV
+        echo "VARIANT_BUILD_DIR=$VARIANT_BUILD_DIR" >> $GITHUB_ENV
+        echo "VARIANT_TAG=$VARIANT_TAG" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF=$VARIANT_TAG_WITH_REF" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF_AND_SHA_SHORT=$VARIANT_TAG_WITH_REF_AND_SHA_SHORT" >> $GITHUB_ENV
 
     - name: Login to docker registry
       if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
@@ -2759,14 +2737,14 @@ jobs:
       id: docker_build_pr
       # Run only on pull requests
       if: github.event_name == 'pull_request'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -2774,28 +2752,28 @@ jobs:
       id: docker_build_master
       # Run only on master
       if: github.ref == 'refs/heads/master'
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Build and push (release)
       id: docker_build_release
       if: startsWith(github.ref, 'refs/tags/')
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
+        context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -2811,7 +2789,6 @@ jobs:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5
         with:
@@ -2825,19 +2802,12 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Resolve tag
-        id: resolve-tag
-        run: |
-          # Get <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. . E.g. 'master', 'v1.2.3'
-          REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
-          echo "::set-output name=REF::$REF"
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5
         with:
           config-name: release-drafter.yml
           publish: true
-          name: ${{ steps.resolve-tag.outputs.REF }}
-          tag: ${{ steps.resolve-tag.outputs.REF }}
+          name: ${{ github.ref_name }} # E.g. 'master' or 'v1.2.3'
+          tag: ${{ github.ref_name }} # E.g. 'master' or 'v1.2.3'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Should have been done in #7