### PR TITLE
Feature: Add `sshpass` in all `ssh` variants

### DIFF
--- a/generate/templates/Dockerfile.ps1
+++ b/generate/templates/Dockerfile.ps1
@@ -49,7 +49,7 @@ RUN apk add --no-cache gnupg
 
 if ( $VARIANT['_metadata']['components'] -contains 'ssh' ) {
     @"
-RUN apk add --no-cache openssh-client
+RUN apk add --no-cache openssh-client sshpass
 
 
 "@

--- a/variants/v0.11.0-jq-sops-ssh-alpine-3.7/Dockerfile
+++ b/variants/v0.11.0-jq-sops-ssh-alpine-3.7/Dockerfile
@@ -11,6 +11,6 @@ RUN wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7
 
 RUN apk add --no-cache gnupg
 
-RUN apk add --no-cache openssh-client
+RUN apk add --no-cache openssh-client sshpass
 
 CMD [ "terraform" ]

--- a/variants/v0.11.7-jq-sops-ssh-alpine-3.8/Dockerfile
+++ b/variants/v0.11.7-jq-sops-ssh-alpine-3.8/Dockerfile
@@ -11,6 +11,6 @@ RUN wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7
 
 RUN apk add --no-cache gnupg
 
-RUN apk add --no-cache openssh-client
+RUN apk add --no-cache openssh-client sshpass
 
 CMD [ "terraform" ]

--- a/variants/v0.11.8-jq-sops-ssh-alpine-3.9/Dockerfile
+++ b/variants/v0.11.8-jq-sops-ssh-alpine-3.9/Dockerfile
@@ -11,6 +11,6 @@ RUN wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7
 
 RUN apk add --no-cache gnupg
 
-RUN apk add --no-cache openssh-client
+RUN apk add --no-cache openssh-client sshpass
 
 CMD [ "terraform" ]

--- a/variants/v0.12.17-jq-sops-ssh-alpine-3.11/Dockerfile
+++ b/variants/v0.12.17-jq-sops-ssh-alpine-3.11/Dockerfile
@@ -11,6 +11,6 @@ RUN wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7
 
 RUN apk add --no-cache gnupg
 
-RUN apk add --no-cache openssh-client
+RUN apk add --no-cache openssh-client sshpass
 
 CMD [ "terraform" ]

--- a/variants/v0.12.25-jq-sops-ssh-alpine-3.12/Dockerfile
+++ b/variants/v0.12.25-jq-sops-ssh-alpine-3.12/Dockerfile
@@ -11,6 +11,6 @@ RUN wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7
 
 RUN apk add --no-cache gnupg
 
-RUN apk add --no-cache openssh-client
+RUN apk add --no-cache openssh-client sshpass
 
 CMD [ "terraform" ]

--- a/variants/v0.12.6-jq-sops-ssh-alpine-3.10/Dockerfile
+++ b/variants/v0.12.6-jq-sops-ssh-alpine-3.10/Dockerfile
@@ -11,6 +11,6 @@ RUN wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7
 
 RUN apk add --no-cache gnupg
 
-RUN apk add --no-cache openssh-client
+RUN apk add --no-cache openssh-client sshpass
 
 CMD [ "terraform" ]

--- a/variants/v0.14.4-jq-sops-ssh-alpine-3.13/Dockerfile
+++ b/variants/v0.14.4-jq-sops-ssh-alpine-3.13/Dockerfile
@@ -11,6 +11,6 @@ RUN wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7
 
 RUN apk add --no-cache gnupg
 
-RUN apk add --no-cache openssh-client
+RUN apk add --no-cache openssh-client sshpass
 
 CMD [ "terraform" ]

--- a/variants/v0.14.9-jq-sops-ssh-alpine-3.14/Dockerfile
+++ b/variants/v0.14.9-jq-sops-ssh-alpine-3.14/Dockerfile
@@ -11,6 +11,6 @@ RUN wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7
 
 RUN apk add --no-cache gnupg
 
-RUN apk add --no-cache openssh-client
+RUN apk add --no-cache openssh-client sshpass
 
 CMD [ "terraform" ]

--- a/variants/v0.8.1-jq-sops-ssh-alpine-3.5/Dockerfile
+++ b/variants/v0.8.1-jq-sops-ssh-alpine-3.5/Dockerfile
@@ -20,6 +20,6 @@ RUN apk add --no-cache curl \
 
 RUN apk add --no-cache gnupg
 
-RUN apk add --no-cache openssh-client
+RUN apk add --no-cache openssh-client sshpass
 
 CMD [ "terraform" ]

--- a/variants/v0.9.5-jq-sops-ssh-alpine-3.6/Dockerfile
+++ b/variants/v0.9.5-jq-sops-ssh-alpine-3.6/Dockerfile
@@ -20,6 +20,6 @@ RUN apk add --no-cache curl \
 
 RUN apk add --no-cache gnupg
 
-RUN apk add --no-cache openssh-client
+RUN apk add --no-cache openssh-client sshpass
 
 CMD [ "terraform" ]

--- a/variants/v1.0.11-jq-sops-ssh-alpine-3.15/Dockerfile
+++ b/variants/v1.0.11-jq-sops-ssh-alpine-3.15/Dockerfile
@@ -11,6 +11,6 @@ RUN wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7
 
 RUN apk add --no-cache gnupg
 
-RUN apk add --no-cache openssh-client
+RUN apk add --no-cache openssh-client sshpass
 
 CMD [ "terraform" ]


### PR DESCRIPTION
`sshpass` is to allow passing SSH password non-interactively to `ssh` on the command line.