### PR TITLE
Feature: Add `libvirt` composite variant

### DIFF
--- a/.github/workflows/ci-master-pr.yml
+++ b/.github/workflows/ci-master-pr.yml
@@ -138,6 +138,132 @@ jobs:
       run: docker logout
       if: always()
 
+  build-v1-3-4-jq-libvirt-sops-ssh-alpine-3-17:
+    runs-on: ubuntu-latest
+    env:
+      VARIANT_TAG: v1.3.4-jq-libvirt-sops-ssh-alpine-3.17
+      VARIANT_BUILD_DIR: variants/v1.3.4-jq-libvirt-sops-ssh-alpine-3.17
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Display system info (linux)
+      run: |
+        set -e
+        hostname
+        whoami
+        cat /etc/*release
+        lscpu
+        free
+        df -h
+        pwd
+        docker info
+        docker version
+
+    # See: https://github.com/docker/build-push-action/blob/v2.6.1/docs/advanced/cache.md#github-cache
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@master
+
+    - name: Cache Docker layers
+      uses: actions/cache@v3
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-
+
+    - name: Prepare
+      id: prep
+      run: |
+        set -e
+
+        # Get 'namespace' and 'project-name' from 'namespace/project-name'
+        # CI_PROJECT_NAMESPACE=$( echo "${{ github.repository }}" | cut -d '/' -f 1 )
+        # CI_PROJECT_NAME=$( echo "${{ github.repository }}" | cut -d '/' -f 2 )
+
+        # Get ref, i.e. <branch_name> from refs/heads/<branch_name>, or <tag-name> from refs/tags/<tag_name>. E.g. 'master' or 'v1.2.3'
+        REF=$( echo "${GITHUB_REF}" | rev | cut -d '/' -f 1 | rev )
+
+        # Get commit hash E.g. 'b29758a'
+        SHA_SHORT=$( echo "${GITHUB_SHA}" | cut -c1-7 )
+
+        # Generate the final tags. E.g. 'master-mytag' and 'master-b29758a-mytag'
+        VARIANT_TAG_WITH_REF="${REF}-${VARIANT_TAG}"
+        VARIANT_TAG_WITH_REF_AND_SHA_SHORT="${REF}-${SHA_SHORT}-${VARIANT_TAG}"
+
+        # Pass variables to next step
+        # echo "CI_PROJECT_NAMESPACE=$CI_PROJECT_NAMESPACE" >> $GITHUB_ENV
+        # echo "CI_PROJECT_NAME=$CI_PROJECT_NAME" >> $GITHUB_ENV
+        # echo "REF=$REF" >> $GITHUB_ENV
+        # echo "SHA_SHORT=$SHA_SHORT" >> $GITHUB_ENV
+        # echo "REF_AND_SHA_SHORT=$REF_AND_SHA_SHORT" >> $GITHUB_ENV
+        echo "VARIANT_BUILD_DIR=$VARIANT_BUILD_DIR" >> $GITHUB_ENV
+        echo "VARIANT_TAG=$VARIANT_TAG" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF=$VARIANT_TAG_WITH_REF" >> $GITHUB_ENV
+        echo "VARIANT_TAG_WITH_REF_AND_SHA_SHORT=$VARIANT_TAG_WITH_REF_AND_SHA_SHORT" >> $GITHUB_ENV
+
+    - name: Login to docker registry
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
+      run: echo "${DOCKERHUB_REGISTRY_PASSWORD}" | docker login -u "${DOCKERHUB_REGISTRY_USER}" --password-stdin
+      env:
+        DOCKERHUB_REGISTRY_USER: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
+        DOCKERHUB_REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_REGISTRY_PASSWORD }}
+
+    - name: Build (PRs)
+      id: docker_build_pr
+      # Run only on pull requests
+      if: github.event_name == 'pull_request'
+      uses: docker/build-push-action@v3
+      with:
+        context: ${{ env.VARIANT_BUILD_DIR }}
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: false
+        tags: |
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache
+
+    - name: Build and push (master)
+      id: docker_build_master
+      # Run only on master
+      if: github.ref == 'refs/heads/master'
+      uses: docker/build-push-action@v3
+      with:
+        context: ${{ env.VARIANT_BUILD_DIR }}
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: true
+        tags: |
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+        cache-to: type=local,dest=/tmp/.buildx-cache
+
+    - name: Build and push (release)
+      id: docker_build_release
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: docker/build-push-action@v3
+      with:
+        context: ${{ env.VARIANT_BUILD_DIR }}
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
+        push: true
+        tags: |
+          ${{ github.repository }}:${{ env.VARIANT_TAG }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
+          ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache
+
+    - name: List docker images
+      run: docker images
+
+    - name: Clean-up
+      run: docker logout
+      if: always()
+
   build-v1-2-0-jq-sops-ssh-alpine-3-16:
     runs-on: ubuntu-latest
     env:
@@ -1651,7 +1777,7 @@ jobs:
       if: always()
 
   update-draft-release:
-    needs: [build-v1-3-4-jq-sops-ssh-alpine-3-17, build-v1-2-0-jq-sops-ssh-alpine-3-16, build-v1-0-11-jq-sops-ssh-alpine-3-15, build-v0-14-9-jq-sops-ssh-alpine-3-14, build-v0-14-4-jq-sops-ssh-alpine-3-13, build-v0-12-25-jq-sops-ssh-alpine-3-12, build-v0-12-17-jq-sops-ssh-alpine-3-11, build-v0-12-6-jq-sops-ssh-alpine-3-10, build-v0-11-8-jq-sops-ssh-alpine-3-9, build-v0-11-7-jq-sops-ssh-alpine-3-8, build-v0-11-0-jq-sops-ssh-alpine-3-7, build-v0-9-5-jq-sops-ssh-alpine-3-6, build-v0-8-1-jq-sops-ssh-alpine-3-5]
+    needs: [build-v1-3-4-jq-sops-ssh-alpine-3-17, build-v1-3-4-jq-libvirt-sops-ssh-alpine-3-17, build-v1-2-0-jq-sops-ssh-alpine-3-16, build-v1-0-11-jq-sops-ssh-alpine-3-15, build-v0-14-9-jq-sops-ssh-alpine-3-14, build-v0-14-4-jq-sops-ssh-alpine-3-13, build-v0-12-25-jq-sops-ssh-alpine-3-12, build-v0-12-17-jq-sops-ssh-alpine-3-11, build-v0-12-6-jq-sops-ssh-alpine-3-10, build-v0-11-8-jq-sops-ssh-alpine-3-9, build-v0-11-7-jq-sops-ssh-alpine-3-8, build-v0-11-0-jq-sops-ssh-alpine-3-7, build-v0-9-5-jq-sops-ssh-alpine-3-6, build-v0-8-1-jq-sops-ssh-alpine-3-5]
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
@@ -1664,7 +1790,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-draft-release:
-    needs: [build-v1-3-4-jq-sops-ssh-alpine-3-17, build-v1-2-0-jq-sops-ssh-alpine-3-16, build-v1-0-11-jq-sops-ssh-alpine-3-15, build-v0-14-9-jq-sops-ssh-alpine-3-14, build-v0-14-4-jq-sops-ssh-alpine-3-13, build-v0-12-25-jq-sops-ssh-alpine-3-12, build-v0-12-17-jq-sops-ssh-alpine-3-11, build-v0-12-6-jq-sops-ssh-alpine-3-10, build-v0-11-8-jq-sops-ssh-alpine-3-9, build-v0-11-7-jq-sops-ssh-alpine-3-8, build-v0-11-0-jq-sops-ssh-alpine-3-7, build-v0-9-5-jq-sops-ssh-alpine-3-6, build-v0-8-1-jq-sops-ssh-alpine-3-5]
+    needs: [build-v1-3-4-jq-sops-ssh-alpine-3-17, build-v1-3-4-jq-libvirt-sops-ssh-alpine-3-17, build-v1-2-0-jq-sops-ssh-alpine-3-16, build-v1-0-11-jq-sops-ssh-alpine-3-15, build-v0-14-9-jq-sops-ssh-alpine-3-14, build-v0-14-4-jq-sops-ssh-alpine-3-13, build-v0-12-25-jq-sops-ssh-alpine-3-12, build-v0-12-17-jq-sops-ssh-alpine-3-11, build-v0-12-6-jq-sops-ssh-alpine-3-10, build-v0-11-8-jq-sops-ssh-alpine-3-9, build-v0-11-7-jq-sops-ssh-alpine-3-8, build-v0-11-0-jq-sops-ssh-alpine-3-7, build-v0-9-5-jq-sops-ssh-alpine-3-6, build-v0-8-1-jq-sops-ssh-alpine-3-5]
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The base image is `alpine`, and not the closed-source [`hashicorp/terraform` ima
 | Tag | Dockerfile Build Context |
 |:-------:|:---------:|
 | `:v1.3.4-jq-sops-ssh-alpine-3.17`, `:latest` | [View](variants/v1.3.4-jq-sops-ssh-alpine-3.17 ) |
+| `:v1.3.4-jq-libvirt-sops-ssh-alpine-3.17` | [View](variants/v1.3.4-jq-libvirt-sops-ssh-alpine-3.17 ) |
 | `:v1.2.0-jq-sops-ssh-alpine-3.16` | [View](variants/v1.2.0-jq-sops-ssh-alpine-3.16 ) |
 | `:v1.0.11-jq-sops-ssh-alpine-3.15` | [View](variants/v1.0.11-jq-sops-ssh-alpine-3.15 ) |
 | `:v0.14.9-jq-sops-ssh-alpine-3.14` | [View](variants/v0.14.9-jq-sops-ssh-alpine-3.14 ) |

--- a/generate/definitions/VARIANTS.ps1
+++ b/generate/definitions/VARIANTS.ps1
@@ -7,6 +7,7 @@ $local:VARIANTS_MATRIX = @(
         distro_version = '3.17'
         subvariants = @(
             @{ components = @( 'jq', 'sops', 'ssh' ); tag_as_latest = $true }
+            @{ components = @( 'jq', 'libvirt', 'sops', 'ssh' )}
         )
     }
     @{
@@ -15,7 +16,7 @@ $local:VARIANTS_MATRIX = @(
         distro = 'alpine'
         distro_version = '3.16'
         subvariants = @(
-            @{ components = @( 'jq', 'sops', 'ssh' ); }
+            @{ components = @( 'jq', 'sops', 'ssh' ) }
         )
     }
     @{
@@ -24,7 +25,7 @@ $local:VARIANTS_MATRIX = @(
         distro = 'alpine'
         distro_version = '3.15'
         subvariants = @(
-            @{ components = @( 'jq', 'sops', 'ssh' ); }
+            @{ components = @( 'jq', 'sops', 'ssh' ) }
         )
     }
     @{

--- a/generate/templates/Dockerfile.ps1
+++ b/generate/templates/Dockerfile.ps1
@@ -17,6 +17,14 @@ RUN apk add --no-cache jq
 "@
 }
 
+if ( $VARIANT['_metadata']['components'] -contains 'libvirt' ) {
+    @"
+RUN apk add --no-cache libvirt-client
+
+
+"@
+}
+
 if ( $VARIANT['_metadata']['components'] -contains 'sops' ) {
     if ( $VARIANT['_metadata']['distro'] -eq 'alpine' -and $VARIANT['_metadata']['distro_version'] -in @('3.6', '3.5', '3.4', '3.3') ) {
         @"

--- a/variants/v1.3.4-jq-libvirt-sops-ssh-alpine-3.17/Dockerfile
+++ b/variants/v1.3.4-jq-libvirt-sops-ssh-alpine-3.17/Dockerfile
@@ -1,0 +1,18 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache terraform=1.3.4-r0
+
+RUN apk add --no-cache jq
+
+RUN apk add --no-cache libvirt-client
+
+RUN wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client sshpass
+
+CMD [ "terraform" ]


### PR DESCRIPTION
Some platforms e.g. `linux/s390x` don't have `libvirt-client` package on `alpine:3.15` and `alpine:3.16`, so we'll build `alpine:3.17` for now.