### PR TITLE
Enhancement: Add `CHECKPOINT_DISABLE=1` to disable telemetry in all variants

### DIFF
--- a/generate/templates/Dockerfile.ps1
+++ b/generate/templates/Dockerfile.ps1
@@ -64,6 +64,9 @@ RUN apk add --no-cache openssh-client sshpass
 }
 
 @"
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
 CMD [ "terraform" ]
 
 "@

--- a/variants/v0.11.0-jq-sops-ssh-alpine-3.7/Dockerfile
+++ b/variants/v0.11.0-jq-sops-ssh-alpine-3.7/Dockerfile
@@ -13,4 +13,7 @@ RUN apk add --no-cache gnupg
 
 RUN apk add --no-cache openssh-client sshpass
 
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
 CMD [ "terraform" ]

--- a/variants/v0.11.7-jq-sops-ssh-alpine-3.8/Dockerfile
+++ b/variants/v0.11.7-jq-sops-ssh-alpine-3.8/Dockerfile
@@ -13,4 +13,7 @@ RUN apk add --no-cache gnupg
 
 RUN apk add --no-cache openssh-client sshpass
 
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
 CMD [ "terraform" ]

--- a/variants/v0.11.8-jq-sops-ssh-alpine-3.9/Dockerfile
+++ b/variants/v0.11.8-jq-sops-ssh-alpine-3.9/Dockerfile
@@ -13,4 +13,7 @@ RUN apk add --no-cache gnupg
 
 RUN apk add --no-cache openssh-client sshpass
 
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
 CMD [ "terraform" ]

--- a/variants/v0.12.17-jq-sops-ssh-alpine-3.11/Dockerfile
+++ b/variants/v0.12.17-jq-sops-ssh-alpine-3.11/Dockerfile
@@ -13,4 +13,7 @@ RUN apk add --no-cache gnupg
 
 RUN apk add --no-cache openssh-client sshpass
 
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
 CMD [ "terraform" ]

--- a/variants/v0.12.25-jq-sops-ssh-alpine-3.12/Dockerfile
+++ b/variants/v0.12.25-jq-sops-ssh-alpine-3.12/Dockerfile
@@ -13,4 +13,7 @@ RUN apk add --no-cache gnupg
 
 RUN apk add --no-cache openssh-client sshpass
 
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
 CMD [ "terraform" ]

--- a/variants/v0.12.6-jq-sops-ssh-alpine-3.10/Dockerfile
+++ b/variants/v0.12.6-jq-sops-ssh-alpine-3.10/Dockerfile
@@ -13,4 +13,7 @@ RUN apk add --no-cache gnupg
 
 RUN apk add --no-cache openssh-client sshpass
 
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
 CMD [ "terraform" ]

--- a/variants/v0.14.4-jq-sops-ssh-alpine-3.13/Dockerfile
+++ b/variants/v0.14.4-jq-sops-ssh-alpine-3.13/Dockerfile
@@ -13,4 +13,7 @@ RUN apk add --no-cache gnupg
 
 RUN apk add --no-cache openssh-client sshpass
 
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
 CMD [ "terraform" ]

--- a/variants/v0.14.9-jq-sops-ssh-alpine-3.14/Dockerfile
+++ b/variants/v0.14.9-jq-sops-ssh-alpine-3.14/Dockerfile
@@ -13,4 +13,7 @@ RUN apk add --no-cache gnupg
 
 RUN apk add --no-cache openssh-client sshpass
 
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
 CMD [ "terraform" ]

--- a/variants/v0.8.1-jq-sops-ssh-alpine-3.5/Dockerfile
+++ b/variants/v0.8.1-jq-sops-ssh-alpine-3.5/Dockerfile
@@ -22,4 +22,7 @@ RUN apk add --no-cache gnupg
 
 RUN apk add --no-cache openssh-client sshpass
 
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
 CMD [ "terraform" ]

--- a/variants/v0.9.5-jq-sops-ssh-alpine-3.6/Dockerfile
+++ b/variants/v0.9.5-jq-sops-ssh-alpine-3.6/Dockerfile
@@ -22,4 +22,7 @@ RUN apk add --no-cache gnupg
 
 RUN apk add --no-cache openssh-client sshpass
 
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
 CMD [ "terraform" ]

--- a/variants/v1.0.11-jq-sops-ssh-alpine-3.15/Dockerfile
+++ b/variants/v1.0.11-jq-sops-ssh-alpine-3.15/Dockerfile
@@ -13,4 +13,7 @@ RUN apk add --no-cache gnupg
 
 RUN apk add --no-cache openssh-client sshpass
 
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
 CMD [ "terraform" ]

--- a/variants/v1.2.0-jq-sops-ssh-alpine-3.16/Dockerfile
+++ b/variants/v1.2.0-jq-sops-ssh-alpine-3.16/Dockerfile
@@ -13,4 +13,7 @@ RUN apk add --no-cache gnupg
 
 RUN apk add --no-cache openssh-client sshpass
 
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
 CMD [ "terraform" ]

--- a/variants/v1.3.4-jq-libvirt-sops-ssh-alpine-3.17/Dockerfile
+++ b/variants/v1.3.4-jq-libvirt-sops-ssh-alpine-3.17/Dockerfile
@@ -15,4 +15,7 @@ RUN apk add --no-cache gnupg
 
 RUN apk add --no-cache openssh-client sshpass
 
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
 CMD [ "terraform" ]

--- a/variants/v1.3.4-jq-sops-ssh-alpine-3.17/Dockerfile
+++ b/variants/v1.3.4-jq-sops-ssh-alpine-3.17/Dockerfile
@@ -13,4 +13,7 @@ RUN apk add --no-cache gnupg
 
 RUN apk add --no-cache openssh-client sshpass
 
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
 CMD [ "terraform" ]


### PR DESCRIPTION
This stops `terraform` from querying for updates (not needed in docker images) and sending telemetry data. This ensures no unnecessary network calls are made when using terraform, so that terraform can be used in environments without internet connection.