### PR TITLE
Change: Remove `v` prefix from docker tags

### DIFF
--- a/.github/workflows/ci-master-pr.yml
+++ b/.github/workflows/ci-master-pr.yml
@@ -79,7 +79,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-5-7
+      id: prep-1-5-7
       run: |
         set -e
 
@@ -92,7 +92,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.5.7"
+        VARIANT="1.5.7"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -102,52 +102,52 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.5.7 - Build (PRs)
+    - name: 1.5.7 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.5.7
+        context: variants/1.5.7
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-5-7.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-5-7.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-5-7.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-5-7.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.5.7 - Build and push (master)
+    - name: 1.5.7 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.5.7
+        context: variants/1.5.7
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-5-7.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-5-7.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-5-7.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-5-7.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.5.7 - Build and push (release)
+    - name: 1.5.7 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.5.7
+        context: variants/1.5.7
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-5-7.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-5-7.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-5-7.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-5-7.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-5-7.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-5-7.outputs.REF_SHA_VARIANT }}
           ${{ github.repository }}:latest
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-5-7-jq-sops-ssh
+      id: prep-1-5-7-jq-sops-ssh
       run: |
         set -e
 
@@ -160,7 +160,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.5.7-jq-sops-ssh"
+        VARIANT="1.5.7-jq-sops-ssh"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -170,51 +170,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.5.7-jq-sops-ssh - Build (PRs)
+    - name: 1.5.7-jq-sops-ssh - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.5.7-jq-sops-ssh
+        context: variants/1.5.7-jq-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-5-7-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-5-7-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-5-7-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-5-7-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.5.7-jq-sops-ssh - Build and push (master)
+    - name: 1.5.7-jq-sops-ssh - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.5.7-jq-sops-ssh
+        context: variants/1.5.7-jq-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-5-7-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-5-7-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-5-7-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-5-7-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.5.7-jq-sops-ssh - Build and push (release)
+    - name: 1.5.7-jq-sops-ssh - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.5.7-jq-sops-ssh
+        context: variants/1.5.7-jq-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-5-7-jq-sops-ssh.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-5-7-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-5-7-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-5-7-jq-sops-ssh.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-5-7-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-5-7-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-5-7-jq-libvirt-sops-ssh
+      id: prep-1-5-7-jq-libvirt-sops-ssh
       run: |
         set -e
 
@@ -227,7 +227,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.5.7-jq-libvirt-sops-ssh"
+        VARIANT="1.5.7-jq-libvirt-sops-ssh"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -237,45 +237,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.5.7-jq-libvirt-sops-ssh - Build (PRs)
+    - name: 1.5.7-jq-libvirt-sops-ssh - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.5.7-jq-libvirt-sops-ssh
+        context: variants/1.5.7-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-5-7-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-5-7-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-5-7-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-5-7-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.5.7-jq-libvirt-sops-ssh - Build and push (master)
+    - name: 1.5.7-jq-libvirt-sops-ssh - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.5.7-jq-libvirt-sops-ssh
+        context: variants/1.5.7-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-5-7-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-5-7-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-5-7-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-5-7-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.5.7-jq-libvirt-sops-ssh - Build and push (release)
+    - name: 1.5.7-jq-libvirt-sops-ssh - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.5.7-jq-libvirt-sops-ssh
+        context: variants/1.5.7-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-5-7-jq-libvirt-sops-ssh.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-5-7-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-5-7-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-5-7-jq-libvirt-sops-ssh.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-5-7-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-5-7-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -333,7 +333,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-4-7
+      id: prep-1-4-7
       run: |
         set -e
 
@@ -346,7 +346,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.4.7"
+        VARIANT="1.4.7"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -356,51 +356,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.4.7 - Build (PRs)
+    - name: 1.4.7 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.4.7
+        context: variants/1.4.7
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-4-7.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-4-7.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-4-7.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-4-7.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.4.7 - Build and push (master)
+    - name: 1.4.7 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.4.7
+        context: variants/1.4.7
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-4-7.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-4-7.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-4-7.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-4-7.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.4.7 - Build and push (release)
+    - name: 1.4.7 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.4.7
+        context: variants/1.4.7
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-4-7.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-4-7.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-4-7.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-4-7.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-4-7.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-4-7.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-4-7-jq-sops-ssh
+      id: prep-1-4-7-jq-sops-ssh
       run: |
         set -e
 
@@ -413,7 +413,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.4.7-jq-sops-ssh"
+        VARIANT="1.4.7-jq-sops-ssh"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -423,51 +423,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.4.7-jq-sops-ssh - Build (PRs)
+    - name: 1.4.7-jq-sops-ssh - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.4.7-jq-sops-ssh
+        context: variants/1.4.7-jq-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-4-7-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-4-7-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-4-7-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-4-7-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.4.7-jq-sops-ssh - Build and push (master)
+    - name: 1.4.7-jq-sops-ssh - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.4.7-jq-sops-ssh
+        context: variants/1.4.7-jq-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-4-7-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-4-7-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-4-7-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-4-7-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.4.7-jq-sops-ssh - Build and push (release)
+    - name: 1.4.7-jq-sops-ssh - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.4.7-jq-sops-ssh
+        context: variants/1.4.7-jq-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-4-7-jq-sops-ssh.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-4-7-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-4-7-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-4-7-jq-sops-ssh.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-4-7-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-4-7-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-4-7-jq-libvirt-sops-ssh
+      id: prep-1-4-7-jq-libvirt-sops-ssh
       run: |
         set -e
 
@@ -480,7 +480,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.4.7-jq-libvirt-sops-ssh"
+        VARIANT="1.4.7-jq-libvirt-sops-ssh"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -490,45 +490,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.4.7-jq-libvirt-sops-ssh - Build (PRs)
+    - name: 1.4.7-jq-libvirt-sops-ssh - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.4.7-jq-libvirt-sops-ssh
+        context: variants/1.4.7-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-4-7-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-4-7-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-4-7-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-4-7-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.4.7-jq-libvirt-sops-ssh - Build and push (master)
+    - name: 1.4.7-jq-libvirt-sops-ssh - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.4.7-jq-libvirt-sops-ssh
+        context: variants/1.4.7-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-4-7-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-4-7-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-4-7-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-4-7-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.4.7-jq-libvirt-sops-ssh - Build and push (release)
+    - name: 1.4.7-jq-libvirt-sops-ssh - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.4.7-jq-libvirt-sops-ssh
+        context: variants/1.4.7-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-4-7-jq-libvirt-sops-ssh.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-4-7-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-4-7-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-4-7-jq-libvirt-sops-ssh.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-4-7-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-4-7-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -586,7 +586,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-3-10
+      id: prep-1-3-10
       run: |
         set -e
 
@@ -599,7 +599,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.3.10"
+        VARIANT="1.3.10"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -609,51 +609,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.3.10 - Build (PRs)
+    - name: 1.3.10 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.3.10
+        context: variants/1.3.10
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-3-10.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-3-10.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-3-10.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-3-10.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.3.10 - Build and push (master)
+    - name: 1.3.10 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.3.10
+        context: variants/1.3.10
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-3-10.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-3-10.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-3-10.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-3-10.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.3.10 - Build and push (release)
+    - name: 1.3.10 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.3.10
+        context: variants/1.3.10
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-3-10.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-3-10.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-3-10.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-3-10.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-3-10.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-3-10.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-3-10-jq-sops-ssh
+      id: prep-1-3-10-jq-sops-ssh
       run: |
         set -e
 
@@ -666,7 +666,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.3.10-jq-sops-ssh"
+        VARIANT="1.3.10-jq-sops-ssh"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -676,51 +676,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.3.10-jq-sops-ssh - Build (PRs)
+    - name: 1.3.10-jq-sops-ssh - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.3.10-jq-sops-ssh
+        context: variants/1.3.10-jq-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-3-10-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-3-10-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-3-10-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-3-10-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.3.10-jq-sops-ssh - Build and push (master)
+    - name: 1.3.10-jq-sops-ssh - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.3.10-jq-sops-ssh
+        context: variants/1.3.10-jq-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-3-10-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-3-10-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-3-10-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-3-10-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.3.10-jq-sops-ssh - Build and push (release)
+    - name: 1.3.10-jq-sops-ssh - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.3.10-jq-sops-ssh
+        context: variants/1.3.10-jq-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-3-10-jq-sops-ssh.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-3-10-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-3-10-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-3-10-jq-sops-ssh.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-3-10-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-3-10-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-3-10-jq-libvirt-sops-ssh
+      id: prep-1-3-10-jq-libvirt-sops-ssh
       run: |
         set -e
 
@@ -733,7 +733,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.3.10-jq-libvirt-sops-ssh"
+        VARIANT="1.3.10-jq-libvirt-sops-ssh"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -743,45 +743,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.3.10-jq-libvirt-sops-ssh - Build (PRs)
+    - name: 1.3.10-jq-libvirt-sops-ssh - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.3.10-jq-libvirt-sops-ssh
+        context: variants/1.3.10-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-3-10-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-3-10-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-3-10-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-3-10-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.3.10-jq-libvirt-sops-ssh - Build and push (master)
+    - name: 1.3.10-jq-libvirt-sops-ssh - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.3.10-jq-libvirt-sops-ssh
+        context: variants/1.3.10-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-3-10-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-3-10-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-3-10-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-3-10-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.3.10-jq-libvirt-sops-ssh - Build and push (release)
+    - name: 1.3.10-jq-libvirt-sops-ssh - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.3.10-jq-libvirt-sops-ssh
+        context: variants/1.3.10-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-3-10-jq-libvirt-sops-ssh.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-3-10-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-3-10-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-3-10-jq-libvirt-sops-ssh.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-3-10-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-3-10-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -839,7 +839,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-2-9
+      id: prep-1-2-9
       run: |
         set -e
 
@@ -852,7 +852,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.2.9"
+        VARIANT="1.2.9"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -862,51 +862,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.2.9 - Build (PRs)
+    - name: 1.2.9 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.2.9
+        context: variants/1.2.9
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-2-9.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-2-9.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-2-9.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-2-9.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.2.9 - Build and push (master)
+    - name: 1.2.9 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.2.9
+        context: variants/1.2.9
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-2-9.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-2-9.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-2-9.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-2-9.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.2.9 - Build and push (release)
+    - name: 1.2.9 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.2.9
+        context: variants/1.2.9
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-2-9.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-2-9.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-2-9.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-2-9.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-2-9.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-2-9.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-2-9-jq-sops-ssh
+      id: prep-1-2-9-jq-sops-ssh
       run: |
         set -e
 
@@ -919,7 +919,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.2.9-jq-sops-ssh"
+        VARIANT="1.2.9-jq-sops-ssh"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -929,51 +929,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.2.9-jq-sops-ssh - Build (PRs)
+    - name: 1.2.9-jq-sops-ssh - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.2.9-jq-sops-ssh
+        context: variants/1.2.9-jq-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-2-9-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-2-9-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-2-9-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-2-9-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.2.9-jq-sops-ssh - Build and push (master)
+    - name: 1.2.9-jq-sops-ssh - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.2.9-jq-sops-ssh
+        context: variants/1.2.9-jq-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-2-9-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-2-9-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-2-9-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-2-9-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.2.9-jq-sops-ssh - Build and push (release)
+    - name: 1.2.9-jq-sops-ssh - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.2.9-jq-sops-ssh
+        context: variants/1.2.9-jq-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-2-9-jq-sops-ssh.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-2-9-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-2-9-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-2-9-jq-sops-ssh.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-2-9-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-2-9-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-2-9-jq-libvirt-sops-ssh
+      id: prep-1-2-9-jq-libvirt-sops-ssh
       run: |
         set -e
 
@@ -986,7 +986,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.2.9-jq-libvirt-sops-ssh"
+        VARIANT="1.2.9-jq-libvirt-sops-ssh"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -996,45 +996,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.2.9-jq-libvirt-sops-ssh - Build (PRs)
+    - name: 1.2.9-jq-libvirt-sops-ssh - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.2.9-jq-libvirt-sops-ssh
+        context: variants/1.2.9-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-2-9-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-2-9-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-2-9-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-2-9-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.2.9-jq-libvirt-sops-ssh - Build and push (master)
+    - name: 1.2.9-jq-libvirt-sops-ssh - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.2.9-jq-libvirt-sops-ssh
+        context: variants/1.2.9-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-2-9-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-2-9-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-2-9-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-2-9-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.2.9-jq-libvirt-sops-ssh - Build and push (release)
+    - name: 1.2.9-jq-libvirt-sops-ssh - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.2.9-jq-libvirt-sops-ssh
+        context: variants/1.2.9-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-2-9-jq-libvirt-sops-ssh.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-2-9-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-2-9-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-2-9-jq-libvirt-sops-ssh.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-2-9-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-2-9-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -1092,7 +1092,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-1-9
+      id: prep-1-1-9
       run: |
         set -e
 
@@ -1105,7 +1105,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.1.9"
+        VARIANT="1.1.9"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1115,51 +1115,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.1.9 - Build (PRs)
+    - name: 1.1.9 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.1.9
+        context: variants/1.1.9
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-1-9.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-1-9.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-1-9.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-1-9.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.1.9 - Build and push (master)
+    - name: 1.1.9 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.1.9
+        context: variants/1.1.9
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-1-9.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-1-9.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-1-9.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-1-9.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.1.9 - Build and push (release)
+    - name: 1.1.9 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.1.9
+        context: variants/1.1.9
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-1-9.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-1-9.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-1-9.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-1-9.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-1-9.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-1-9.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-1-9-jq-sops-ssh
+      id: prep-1-1-9-jq-sops-ssh
       run: |
         set -e
 
@@ -1172,7 +1172,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.1.9-jq-sops-ssh"
+        VARIANT="1.1.9-jq-sops-ssh"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1182,51 +1182,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.1.9-jq-sops-ssh - Build (PRs)
+    - name: 1.1.9-jq-sops-ssh - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.1.9-jq-sops-ssh
+        context: variants/1.1.9-jq-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-1-9-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-1-9-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-1-9-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-1-9-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.1.9-jq-sops-ssh - Build and push (master)
+    - name: 1.1.9-jq-sops-ssh - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.1.9-jq-sops-ssh
+        context: variants/1.1.9-jq-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-1-9-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-1-9-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-1-9-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-1-9-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.1.9-jq-sops-ssh - Build and push (release)
+    - name: 1.1.9-jq-sops-ssh - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.1.9-jq-sops-ssh
+        context: variants/1.1.9-jq-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-1-9-jq-sops-ssh.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-1-9-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-1-9-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-1-9-jq-sops-ssh.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-1-9-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-1-9-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-1-9-jq-libvirt-sops-ssh
+      id: prep-1-1-9-jq-libvirt-sops-ssh
       run: |
         set -e
 
@@ -1239,7 +1239,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.1.9-jq-libvirt-sops-ssh"
+        VARIANT="1.1.9-jq-libvirt-sops-ssh"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1249,45 +1249,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.1.9-jq-libvirt-sops-ssh - Build (PRs)
+    - name: 1.1.9-jq-libvirt-sops-ssh - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.1.9-jq-libvirt-sops-ssh
+        context: variants/1.1.9-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-1-9-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-1-9-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-1-9-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-1-9-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.1.9-jq-libvirt-sops-ssh - Build and push (master)
+    - name: 1.1.9-jq-libvirt-sops-ssh - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.1.9-jq-libvirt-sops-ssh
+        context: variants/1.1.9-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-1-9-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-1-9-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-1-9-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-1-9-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.1.9-jq-libvirt-sops-ssh - Build and push (release)
+    - name: 1.1.9-jq-libvirt-sops-ssh - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.1.9-jq-libvirt-sops-ssh
+        context: variants/1.1.9-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-1-9-jq-libvirt-sops-ssh.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-1-9-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-1-9-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-1-9-jq-libvirt-sops-ssh.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-1-9-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-1-9-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -1345,7 +1345,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-0-11
+      id: prep-1-0-11
       run: |
         set -e
 
@@ -1358,7 +1358,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.0.11"
+        VARIANT="1.0.11"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1368,51 +1368,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.0.11 - Build (PRs)
+    - name: 1.0.11 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.0.11
+        context: variants/1.0.11
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-0-11.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-0-11.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-0-11.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-0-11.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.0.11 - Build and push (master)
+    - name: 1.0.11 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.0.11
+        context: variants/1.0.11
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-0-11.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-0-11.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-0-11.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-0-11.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.0.11 - Build and push (release)
+    - name: 1.0.11 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.0.11
+        context: variants/1.0.11
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-0-11.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-0-11.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-0-11.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-0-11.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-0-11.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-0-11.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-0-11-jq-sops-ssh
+      id: prep-1-0-11-jq-sops-ssh
       run: |
         set -e
 
@@ -1425,7 +1425,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.0.11-jq-sops-ssh"
+        VARIANT="1.0.11-jq-sops-ssh"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1435,51 +1435,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.0.11-jq-sops-ssh - Build (PRs)
+    - name: 1.0.11-jq-sops-ssh - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.0.11-jq-sops-ssh
+        context: variants/1.0.11-jq-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-0-11-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-0-11-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-0-11-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-0-11-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.0.11-jq-sops-ssh - Build and push (master)
+    - name: 1.0.11-jq-sops-ssh - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.0.11-jq-sops-ssh
+        context: variants/1.0.11-jq-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-0-11-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-0-11-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-0-11-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-0-11-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.0.11-jq-sops-ssh - Build and push (release)
+    - name: 1.0.11-jq-sops-ssh - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.0.11-jq-sops-ssh
+        context: variants/1.0.11-jq-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-0-11-jq-sops-ssh.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-0-11-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-0-11-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-0-11-jq-sops-ssh.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-0-11-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-0-11-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-0-11-jq-libvirt-sops-ssh
+      id: prep-1-0-11-jq-libvirt-sops-ssh
       run: |
         set -e
 
@@ -1492,7 +1492,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.0.11-jq-libvirt-sops-ssh"
+        VARIANT="1.0.11-jq-libvirt-sops-ssh"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1502,45 +1502,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.0.11-jq-libvirt-sops-ssh - Build (PRs)
+    - name: 1.0.11-jq-libvirt-sops-ssh - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.0.11-jq-libvirt-sops-ssh
+        context: variants/1.0.11-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-0-11-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-0-11-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-0-11-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-0-11-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.0.11-jq-libvirt-sops-ssh - Build and push (master)
+    - name: 1.0.11-jq-libvirt-sops-ssh - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.0.11-jq-libvirt-sops-ssh
+        context: variants/1.0.11-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-0-11-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-0-11-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-0-11-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-0-11-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.0.11-jq-libvirt-sops-ssh - Build and push (release)
+    - name: 1.0.11-jq-libvirt-sops-ssh - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.0.11-jq-libvirt-sops-ssh
+        context: variants/1.0.11-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-0-11-jq-libvirt-sops-ssh.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-0-11-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-0-11-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-0-11-jq-libvirt-sops-ssh.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-0-11-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-0-11-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -1598,7 +1598,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v0-15-5
+      id: prep-0-15-5
       run: |
         set -e
 
@@ -1611,7 +1611,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v0.15.5"
+        VARIANT="0.15.5"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1621,51 +1621,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v0.15.5 - Build (PRs)
+    - name: 0.15.5 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.15.5
+        context: variants/0.15.5
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-15-5.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-15-5.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-15-5.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-15-5.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.15.5 - Build and push (master)
+    - name: 0.15.5 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.15.5
+        context: variants/0.15.5
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-15-5.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-15-5.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-15-5.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-15-5.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.15.5 - Build and push (release)
+    - name: 0.15.5 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.15.5
+        context: variants/0.15.5
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-15-5.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-15-5.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-15-5.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-15-5.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-15-5.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-15-5.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v0-15-5-jq-sops-ssh
+      id: prep-0-15-5-jq-sops-ssh
       run: |
         set -e
 
@@ -1678,7 +1678,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v0.15.5-jq-sops-ssh"
+        VARIANT="0.15.5-jq-sops-ssh"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1688,51 +1688,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v0.15.5-jq-sops-ssh - Build (PRs)
+    - name: 0.15.5-jq-sops-ssh - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.15.5-jq-sops-ssh
+        context: variants/0.15.5-jq-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-15-5-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-15-5-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-15-5-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-15-5-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.15.5-jq-sops-ssh - Build and push (master)
+    - name: 0.15.5-jq-sops-ssh - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.15.5-jq-sops-ssh
+        context: variants/0.15.5-jq-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-15-5-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-15-5-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-15-5-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-15-5-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.15.5-jq-sops-ssh - Build and push (release)
+    - name: 0.15.5-jq-sops-ssh - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.15.5-jq-sops-ssh
+        context: variants/0.15.5-jq-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-15-5-jq-sops-ssh.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-15-5-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-15-5-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-15-5-jq-sops-ssh.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-15-5-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-15-5-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v0-15-5-jq-libvirt-sops-ssh
+      id: prep-0-15-5-jq-libvirt-sops-ssh
       run: |
         set -e
 
@@ -1745,7 +1745,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v0.15.5-jq-libvirt-sops-ssh"
+        VARIANT="0.15.5-jq-libvirt-sops-ssh"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1755,45 +1755,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v0.15.5-jq-libvirt-sops-ssh - Build (PRs)
+    - name: 0.15.5-jq-libvirt-sops-ssh - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.15.5-jq-libvirt-sops-ssh
+        context: variants/0.15.5-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-15-5-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-15-5-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-15-5-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-15-5-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.15.5-jq-libvirt-sops-ssh - Build and push (master)
+    - name: 0.15.5-jq-libvirt-sops-ssh - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.15.5-jq-libvirt-sops-ssh
+        context: variants/0.15.5-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-15-5-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-15-5-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-15-5-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-15-5-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.15.5-jq-libvirt-sops-ssh - Build and push (release)
+    - name: 0.15.5-jq-libvirt-sops-ssh - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.15.5-jq-libvirt-sops-ssh
+        context: variants/0.15.5-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-15-5-jq-libvirt-sops-ssh.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-15-5-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-15-5-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-15-5-jq-libvirt-sops-ssh.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-15-5-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-15-5-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -1851,7 +1851,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v0-14-11
+      id: prep-0-14-11
       run: |
         set -e
 
@@ -1864,7 +1864,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v0.14.11"
+        VARIANT="0.14.11"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1874,51 +1874,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v0.14.11 - Build (PRs)
+    - name: 0.14.11 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.14.11
+        context: variants/0.14.11
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-14-11.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-14-11.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-14-11.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-14-11.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.14.11 - Build and push (master)
+    - name: 0.14.11 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.14.11
+        context: variants/0.14.11
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-14-11.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-14-11.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-14-11.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-14-11.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.14.11 - Build and push (release)
+    - name: 0.14.11 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.14.11
+        context: variants/0.14.11
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-14-11.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-14-11.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-14-11.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-14-11.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-14-11.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-14-11.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v0-14-11-jq-sops-ssh
+      id: prep-0-14-11-jq-sops-ssh
       run: |
         set -e
 
@@ -1931,7 +1931,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v0.14.11-jq-sops-ssh"
+        VARIANT="0.14.11-jq-sops-ssh"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1941,51 +1941,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v0.14.11-jq-sops-ssh - Build (PRs)
+    - name: 0.14.11-jq-sops-ssh - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.14.11-jq-sops-ssh
+        context: variants/0.14.11-jq-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-14-11-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-14-11-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-14-11-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-14-11-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.14.11-jq-sops-ssh - Build and push (master)
+    - name: 0.14.11-jq-sops-ssh - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.14.11-jq-sops-ssh
+        context: variants/0.14.11-jq-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-14-11-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-14-11-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-14-11-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-14-11-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.14.11-jq-sops-ssh - Build and push (release)
+    - name: 0.14.11-jq-sops-ssh - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.14.11-jq-sops-ssh
+        context: variants/0.14.11-jq-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-14-11-jq-sops-ssh.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-14-11-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-14-11-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-14-11-jq-sops-ssh.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-14-11-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-14-11-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v0-14-11-jq-libvirt-sops-ssh
+      id: prep-0-14-11-jq-libvirt-sops-ssh
       run: |
         set -e
 
@@ -1998,7 +1998,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v0.14.11-jq-libvirt-sops-ssh"
+        VARIANT="0.14.11-jq-libvirt-sops-ssh"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -2008,45 +2008,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v0.14.11-jq-libvirt-sops-ssh - Build (PRs)
+    - name: 0.14.11-jq-libvirt-sops-ssh - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.14.11-jq-libvirt-sops-ssh
+        context: variants/0.14.11-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-14-11-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-14-11-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-14-11-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-14-11-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.14.11-jq-libvirt-sops-ssh - Build and push (master)
+    - name: 0.14.11-jq-libvirt-sops-ssh - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.14.11-jq-libvirt-sops-ssh
+        context: variants/0.14.11-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-14-11-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-14-11-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-14-11-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-14-11-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.14.11-jq-libvirt-sops-ssh - Build and push (release)
+    - name: 0.14.11-jq-libvirt-sops-ssh - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.14.11-jq-libvirt-sops-ssh
+        context: variants/0.14.11-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-14-11-jq-libvirt-sops-ssh.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-14-11-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-14-11-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-14-11-jq-libvirt-sops-ssh.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-14-11-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-14-11-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -2104,7 +2104,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v0-13-7
+      id: prep-0-13-7
       run: |
         set -e
 
@@ -2117,7 +2117,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v0.13.7"
+        VARIANT="0.13.7"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -2127,51 +2127,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v0.13.7 - Build (PRs)
+    - name: 0.13.7 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.13.7
+        context: variants/0.13.7
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-13-7.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-13-7.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-13-7.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-13-7.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.13.7 - Build and push (master)
+    - name: 0.13.7 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.13.7
+        context: variants/0.13.7
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-13-7.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-13-7.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-13-7.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-13-7.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.13.7 - Build and push (release)
+    - name: 0.13.7 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.13.7
+        context: variants/0.13.7
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-13-7.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-13-7.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-13-7.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-13-7.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-13-7.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-13-7.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v0-13-7-jq-sops-ssh
+      id: prep-0-13-7-jq-sops-ssh
       run: |
         set -e
 
@@ -2184,7 +2184,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v0.13.7-jq-sops-ssh"
+        VARIANT="0.13.7-jq-sops-ssh"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -2194,51 +2194,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v0.13.7-jq-sops-ssh - Build (PRs)
+    - name: 0.13.7-jq-sops-ssh - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.13.7-jq-sops-ssh
+        context: variants/0.13.7-jq-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-13-7-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-13-7-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-13-7-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-13-7-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.13.7-jq-sops-ssh - Build and push (master)
+    - name: 0.13.7-jq-sops-ssh - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.13.7-jq-sops-ssh
+        context: variants/0.13.7-jq-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-13-7-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-13-7-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-13-7-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-13-7-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.13.7-jq-sops-ssh - Build and push (release)
+    - name: 0.13.7-jq-sops-ssh - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.13.7-jq-sops-ssh
+        context: variants/0.13.7-jq-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-13-7-jq-sops-ssh.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-13-7-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-13-7-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-13-7-jq-sops-ssh.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-13-7-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-13-7-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v0-13-7-jq-libvirt-sops-ssh
+      id: prep-0-13-7-jq-libvirt-sops-ssh
       run: |
         set -e
 
@@ -2251,7 +2251,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v0.13.7-jq-libvirt-sops-ssh"
+        VARIANT="0.13.7-jq-libvirt-sops-ssh"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -2261,45 +2261,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v0.13.7-jq-libvirt-sops-ssh - Build (PRs)
+    - name: 0.13.7-jq-libvirt-sops-ssh - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.13.7-jq-libvirt-sops-ssh
+        context: variants/0.13.7-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-13-7-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-13-7-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-13-7-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-13-7-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.13.7-jq-libvirt-sops-ssh - Build and push (master)
+    - name: 0.13.7-jq-libvirt-sops-ssh - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.13.7-jq-libvirt-sops-ssh
+        context: variants/0.13.7-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-13-7-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-13-7-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-13-7-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-13-7-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.13.7-jq-libvirt-sops-ssh - Build and push (release)
+    - name: 0.13.7-jq-libvirt-sops-ssh - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.13.7-jq-libvirt-sops-ssh
+        context: variants/0.13.7-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-13-7-jq-libvirt-sops-ssh.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-13-7-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-13-7-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-13-7-jq-libvirt-sops-ssh.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-13-7-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-13-7-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -2357,7 +2357,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v0-12-31
+      id: prep-0-12-31
       run: |
         set -e
 
@@ -2370,7 +2370,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v0.12.31"
+        VARIANT="0.12.31"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -2380,51 +2380,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v0.12.31 - Build (PRs)
+    - name: 0.12.31 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.12.31
+        context: variants/0.12.31
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-12-31.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-12-31.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-12-31.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-12-31.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.12.31 - Build and push (master)
+    - name: 0.12.31 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.12.31
+        context: variants/0.12.31
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-12-31.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-12-31.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-12-31.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-12-31.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.12.31 - Build and push (release)
+    - name: 0.12.31 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.12.31
+        context: variants/0.12.31
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-12-31.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-12-31.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-12-31.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-12-31.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-12-31.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-12-31.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v0-12-31-jq-sops-ssh
+      id: prep-0-12-31-jq-sops-ssh
       run: |
         set -e
 
@@ -2437,7 +2437,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v0.12.31-jq-sops-ssh"
+        VARIANT="0.12.31-jq-sops-ssh"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -2447,51 +2447,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v0.12.31-jq-sops-ssh - Build (PRs)
+    - name: 0.12.31-jq-sops-ssh - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.12.31-jq-sops-ssh
+        context: variants/0.12.31-jq-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-12-31-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-12-31-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-12-31-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-12-31-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.12.31-jq-sops-ssh - Build and push (master)
+    - name: 0.12.31-jq-sops-ssh - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.12.31-jq-sops-ssh
+        context: variants/0.12.31-jq-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-12-31-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-12-31-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-12-31-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-12-31-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.12.31-jq-sops-ssh - Build and push (release)
+    - name: 0.12.31-jq-sops-ssh - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.12.31-jq-sops-ssh
+        context: variants/0.12.31-jq-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-12-31-jq-sops-ssh.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-12-31-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-12-31-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-12-31-jq-sops-ssh.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-12-31-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-12-31-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v0-12-31-jq-libvirt-sops-ssh
+      id: prep-0-12-31-jq-libvirt-sops-ssh
       run: |
         set -e
 
@@ -2504,7 +2504,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v0.12.31-jq-libvirt-sops-ssh"
+        VARIANT="0.12.31-jq-libvirt-sops-ssh"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -2514,45 +2514,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v0.12.31-jq-libvirt-sops-ssh - Build (PRs)
+    - name: 0.12.31-jq-libvirt-sops-ssh - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.12.31-jq-libvirt-sops-ssh
+        context: variants/0.12.31-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-12-31-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-12-31-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-12-31-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-12-31-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.12.31-jq-libvirt-sops-ssh - Build and push (master)
+    - name: 0.12.31-jq-libvirt-sops-ssh - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.12.31-jq-libvirt-sops-ssh
+        context: variants/0.12.31-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-12-31-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-12-31-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-12-31-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-12-31-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.12.31-jq-libvirt-sops-ssh - Build and push (release)
+    - name: 0.12.31-jq-libvirt-sops-ssh - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.12.31-jq-libvirt-sops-ssh
+        context: variants/0.12.31-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-12-31-jq-libvirt-sops-ssh.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-12-31-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-12-31-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-12-31-jq-libvirt-sops-ssh.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-12-31-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-12-31-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -2610,7 +2610,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v0-11-15
+      id: prep-0-11-15
       run: |
         set -e
 
@@ -2623,7 +2623,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v0.11.15"
+        VARIANT="0.11.15"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -2633,51 +2633,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v0.11.15 - Build (PRs)
+    - name: 0.11.15 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.11.15
+        context: variants/0.11.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-11-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-11-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-11-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-11-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.11.15 - Build and push (master)
+    - name: 0.11.15 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.11.15
+        context: variants/0.11.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-11-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-11-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-11-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-11-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.11.15 - Build and push (release)
+    - name: 0.11.15 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.11.15
+        context: variants/0.11.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-11-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-11-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-11-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-11-15.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-11-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-11-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v0-11-15-jq-sops-ssh
+      id: prep-0-11-15-jq-sops-ssh
       run: |
         set -e
 
@@ -2690,7 +2690,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v0.11.15-jq-sops-ssh"
+        VARIANT="0.11.15-jq-sops-ssh"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -2700,51 +2700,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v0.11.15-jq-sops-ssh - Build (PRs)
+    - name: 0.11.15-jq-sops-ssh - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.11.15-jq-sops-ssh
+        context: variants/0.11.15-jq-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-11-15-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-11-15-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-11-15-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-11-15-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.11.15-jq-sops-ssh - Build and push (master)
+    - name: 0.11.15-jq-sops-ssh - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.11.15-jq-sops-ssh
+        context: variants/0.11.15-jq-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-11-15-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-11-15-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-11-15-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-11-15-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.11.15-jq-sops-ssh - Build and push (release)
+    - name: 0.11.15-jq-sops-ssh - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.11.15-jq-sops-ssh
+        context: variants/0.11.15-jq-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-11-15-jq-sops-ssh.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-11-15-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-11-15-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-11-15-jq-sops-ssh.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-11-15-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-11-15-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v0-11-15-jq-libvirt-sops-ssh
+      id: prep-0-11-15-jq-libvirt-sops-ssh
       run: |
         set -e
 
@@ -2757,7 +2757,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v0.11.15-jq-libvirt-sops-ssh"
+        VARIANT="0.11.15-jq-libvirt-sops-ssh"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -2767,45 +2767,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v0.11.15-jq-libvirt-sops-ssh - Build (PRs)
+    - name: 0.11.15-jq-libvirt-sops-ssh - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.11.15-jq-libvirt-sops-ssh
+        context: variants/0.11.15-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-11-15-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-11-15-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-11-15-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-11-15-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.11.15-jq-libvirt-sops-ssh - Build and push (master)
+    - name: 0.11.15-jq-libvirt-sops-ssh - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.11.15-jq-libvirt-sops-ssh
+        context: variants/0.11.15-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-11-15-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-11-15-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-11-15-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-11-15-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.11.15-jq-libvirt-sops-ssh - Build and push (release)
+    - name: 0.11.15-jq-libvirt-sops-ssh - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.11.15-jq-libvirt-sops-ssh
+        context: variants/0.11.15-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-11-15-jq-libvirt-sops-ssh.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-11-15-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-11-15-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-11-15-jq-libvirt-sops-ssh.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-11-15-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-11-15-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -2863,7 +2863,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v0-10-8
+      id: prep-0-10-8
       run: |
         set -e
 
@@ -2876,7 +2876,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v0.10.8"
+        VARIANT="0.10.8"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -2886,51 +2886,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v0.10.8 - Build (PRs)
+    - name: 0.10.8 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.10.8
+        context: variants/0.10.8
         platforms: linux/386,linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-10-8.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-10-8.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-10-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-10-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.10.8 - Build and push (master)
+    - name: 0.10.8 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.10.8
+        context: variants/0.10.8
         platforms: linux/386,linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-10-8.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-10-8.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-10-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-10-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.10.8 - Build and push (release)
+    - name: 0.10.8 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.10.8
+        context: variants/0.10.8
         platforms: linux/386,linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-10-8.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-10-8.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-10-8.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-10-8.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-10-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-10-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v0-10-8-jq-sops-ssh
+      id: prep-0-10-8-jq-sops-ssh
       run: |
         set -e
 
@@ -2943,7 +2943,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v0.10.8-jq-sops-ssh"
+        VARIANT="0.10.8-jq-sops-ssh"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -2953,51 +2953,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v0.10.8-jq-sops-ssh - Build (PRs)
+    - name: 0.10.8-jq-sops-ssh - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.10.8-jq-sops-ssh
+        context: variants/0.10.8-jq-sops-ssh
         platforms: linux/386,linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-10-8-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-10-8-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-10-8-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-10-8-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.10.8-jq-sops-ssh - Build and push (master)
+    - name: 0.10.8-jq-sops-ssh - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.10.8-jq-sops-ssh
+        context: variants/0.10.8-jq-sops-ssh
         platforms: linux/386,linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-10-8-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-10-8-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-10-8-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-10-8-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.10.8-jq-sops-ssh - Build and push (release)
+    - name: 0.10.8-jq-sops-ssh - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.10.8-jq-sops-ssh
+        context: variants/0.10.8-jq-sops-ssh
         platforms: linux/386,linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-10-8-jq-sops-ssh.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-10-8-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-10-8-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-10-8-jq-sops-ssh.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-10-8-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-10-8-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v0-10-8-jq-libvirt-sops-ssh
+      id: prep-0-10-8-jq-libvirt-sops-ssh
       run: |
         set -e
 
@@ -3010,7 +3010,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v0.10.8-jq-libvirt-sops-ssh"
+        VARIANT="0.10.8-jq-libvirt-sops-ssh"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -3020,45 +3020,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v0.10.8-jq-libvirt-sops-ssh - Build (PRs)
+    - name: 0.10.8-jq-libvirt-sops-ssh - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.10.8-jq-libvirt-sops-ssh
+        context: variants/0.10.8-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-10-8-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-10-8-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-10-8-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-10-8-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.10.8-jq-libvirt-sops-ssh - Build and push (master)
+    - name: 0.10.8-jq-libvirt-sops-ssh - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.10.8-jq-libvirt-sops-ssh
+        context: variants/0.10.8-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-10-8-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-10-8-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-10-8-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-10-8-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.10.8-jq-libvirt-sops-ssh - Build and push (release)
+    - name: 0.10.8-jq-libvirt-sops-ssh - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.10.8-jq-libvirt-sops-ssh
+        context: variants/0.10.8-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-10-8-jq-libvirt-sops-ssh.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-10-8-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-10-8-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-10-8-jq-libvirt-sops-ssh.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-10-8-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-10-8-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -3116,7 +3116,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v0-9-11
+      id: prep-0-9-11
       run: |
         set -e
 
@@ -3129,7 +3129,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v0.9.11"
+        VARIANT="0.9.11"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -3139,51 +3139,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v0.9.11 - Build (PRs)
+    - name: 0.9.11 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.9.11
+        context: variants/0.9.11
         platforms: linux/386,linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-9-11.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-9-11.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-9-11.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-9-11.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.9.11 - Build and push (master)
+    - name: 0.9.11 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.9.11
+        context: variants/0.9.11
         platforms: linux/386,linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-9-11.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-9-11.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-9-11.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-9-11.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.9.11 - Build and push (release)
+    - name: 0.9.11 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.9.11
+        context: variants/0.9.11
         platforms: linux/386,linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-9-11.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-9-11.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-9-11.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-9-11.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-9-11.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-9-11.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v0-9-11-jq-sops-ssh
+      id: prep-0-9-11-jq-sops-ssh
       run: |
         set -e
 
@@ -3196,7 +3196,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v0.9.11-jq-sops-ssh"
+        VARIANT="0.9.11-jq-sops-ssh"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -3206,51 +3206,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v0.9.11-jq-sops-ssh - Build (PRs)
+    - name: 0.9.11-jq-sops-ssh - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.9.11-jq-sops-ssh
+        context: variants/0.9.11-jq-sops-ssh
         platforms: linux/386,linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-9-11-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-9-11-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-9-11-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-9-11-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.9.11-jq-sops-ssh - Build and push (master)
+    - name: 0.9.11-jq-sops-ssh - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.9.11-jq-sops-ssh
+        context: variants/0.9.11-jq-sops-ssh
         platforms: linux/386,linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-9-11-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-9-11-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-9-11-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-9-11-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.9.11-jq-sops-ssh - Build and push (release)
+    - name: 0.9.11-jq-sops-ssh - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.9.11-jq-sops-ssh
+        context: variants/0.9.11-jq-sops-ssh
         platforms: linux/386,linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-9-11-jq-sops-ssh.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-9-11-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-9-11-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-9-11-jq-sops-ssh.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-9-11-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-9-11-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v0-9-11-jq-libvirt-sops-ssh
+      id: prep-0-9-11-jq-libvirt-sops-ssh
       run: |
         set -e
 
@@ -3263,7 +3263,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v0.9.11-jq-libvirt-sops-ssh"
+        VARIANT="0.9.11-jq-libvirt-sops-ssh"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -3273,45 +3273,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v0.9.11-jq-libvirt-sops-ssh - Build (PRs)
+    - name: 0.9.11-jq-libvirt-sops-ssh - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.9.11-jq-libvirt-sops-ssh
+        context: variants/0.9.11-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-9-11-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-9-11-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-9-11-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-9-11-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.9.11-jq-libvirt-sops-ssh - Build and push (master)
+    - name: 0.9.11-jq-libvirt-sops-ssh - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.9.11-jq-libvirt-sops-ssh
+        context: variants/0.9.11-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-9-11-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-9-11-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-9-11-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-9-11-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.9.11-jq-libvirt-sops-ssh - Build and push (release)
+    - name: 0.9.11-jq-libvirt-sops-ssh - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.9.11-jq-libvirt-sops-ssh
+        context: variants/0.9.11-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-9-11-jq-libvirt-sops-ssh.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-9-11-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-9-11-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-9-11-jq-libvirt-sops-ssh.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-9-11-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-9-11-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -3369,7 +3369,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v0-8-8
+      id: prep-0-8-8
       run: |
         set -e
 
@@ -3382,7 +3382,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v0.8.8"
+        VARIANT="0.8.8"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -3392,51 +3392,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v0.8.8 - Build (PRs)
+    - name: 0.8.8 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.8.8
+        context: variants/0.8.8
         platforms: linux/386,linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-8-8.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-8-8.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-8-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-8-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.8.8 - Build and push (master)
+    - name: 0.8.8 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.8.8
+        context: variants/0.8.8
         platforms: linux/386,linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-8-8.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-8-8.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-8-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-8-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.8.8 - Build and push (release)
+    - name: 0.8.8 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.8.8
+        context: variants/0.8.8
         platforms: linux/386,linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-8-8.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-8-8.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-8-8.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-8-8.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-8-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-8-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v0-8-8-jq-sops-ssh
+      id: prep-0-8-8-jq-sops-ssh
       run: |
         set -e
 
@@ -3449,7 +3449,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v0.8.8-jq-sops-ssh"
+        VARIANT="0.8.8-jq-sops-ssh"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -3459,51 +3459,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v0.8.8-jq-sops-ssh - Build (PRs)
+    - name: 0.8.8-jq-sops-ssh - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.8.8-jq-sops-ssh
+        context: variants/0.8.8-jq-sops-ssh
         platforms: linux/386,linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-8-8-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-8-8-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-8-8-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-8-8-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.8.8-jq-sops-ssh - Build and push (master)
+    - name: 0.8.8-jq-sops-ssh - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.8.8-jq-sops-ssh
+        context: variants/0.8.8-jq-sops-ssh
         platforms: linux/386,linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-8-8-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-8-8-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-8-8-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-8-8-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.8.8-jq-sops-ssh - Build and push (release)
+    - name: 0.8.8-jq-sops-ssh - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.8.8-jq-sops-ssh
+        context: variants/0.8.8-jq-sops-ssh
         platforms: linux/386,linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-8-8-jq-sops-ssh.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-8-8-jq-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-8-8-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-8-8-jq-sops-ssh.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-8-8-jq-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-8-8-jq-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v0-8-8-jq-libvirt-sops-ssh
+      id: prep-0-8-8-jq-libvirt-sops-ssh
       run: |
         set -e
 
@@ -3516,7 +3516,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v0.8.8-jq-libvirt-sops-ssh"
+        VARIANT="0.8.8-jq-libvirt-sops-ssh"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -3526,45 +3526,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v0.8.8-jq-libvirt-sops-ssh - Build (PRs)
+    - name: 0.8.8-jq-libvirt-sops-ssh - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.8.8-jq-libvirt-sops-ssh
+        context: variants/0.8.8-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-8-8-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-8-8-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-8-8-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-8-8-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.8.8-jq-libvirt-sops-ssh - Build and push (master)
+    - name: 0.8.8-jq-libvirt-sops-ssh - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.8.8-jq-libvirt-sops-ssh
+        context: variants/0.8.8-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-8-8-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-8-8-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-8-8-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-8-8-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v0.8.8-jq-libvirt-sops-ssh - Build and push (release)
+    - name: 0.8.8-jq-libvirt-sops-ssh - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v0.8.8-jq-libvirt-sops-ssh
+        context: variants/0.8.8-jq-libvirt-sops-ssh
         platforms: linux/386,linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v0-8-8-jq-libvirt-sops-ssh.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-8-8-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v0-8-8-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-8-8-jq-libvirt-sops-ssh.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-8-8-jq-libvirt-sops-ssh.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-0-8-8-jq-libvirt-sops-ssh.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 

--- a/README.md
+++ b/README.md
@@ -12,48 +12,48 @@ The base image is `alpine`, and not the closed-source [`hashicorp/terraform` ima
 
 | Tag | Dockerfile Build Context |
 |:-------:|:---------:|
-| `:v1.5.7`, `:latest` | [View](variants/v1.5.7) |
-| `:v1.5.7-jq-sops-ssh` | [View](variants/v1.5.7-jq-sops-ssh) |
-| `:v1.5.7-jq-libvirt-sops-ssh` | [View](variants/v1.5.7-jq-libvirt-sops-ssh) |
-| `:v1.4.7` | [View](variants/v1.4.7) |
-| `:v1.4.7-jq-sops-ssh` | [View](variants/v1.4.7-jq-sops-ssh) |
-| `:v1.4.7-jq-libvirt-sops-ssh` | [View](variants/v1.4.7-jq-libvirt-sops-ssh) |
-| `:v1.3.10` | [View](variants/v1.3.10) |
-| `:v1.3.10-jq-sops-ssh` | [View](variants/v1.3.10-jq-sops-ssh) |
-| `:v1.3.10-jq-libvirt-sops-ssh` | [View](variants/v1.3.10-jq-libvirt-sops-ssh) |
-| `:v1.2.9` | [View](variants/v1.2.9) |
-| `:v1.2.9-jq-sops-ssh` | [View](variants/v1.2.9-jq-sops-ssh) |
-| `:v1.2.9-jq-libvirt-sops-ssh` | [View](variants/v1.2.9-jq-libvirt-sops-ssh) |
-| `:v1.1.9` | [View](variants/v1.1.9) |
-| `:v1.1.9-jq-sops-ssh` | [View](variants/v1.1.9-jq-sops-ssh) |
-| `:v1.1.9-jq-libvirt-sops-ssh` | [View](variants/v1.1.9-jq-libvirt-sops-ssh) |
-| `:v1.0.11` | [View](variants/v1.0.11) |
-| `:v1.0.11-jq-sops-ssh` | [View](variants/v1.0.11-jq-sops-ssh) |
-| `:v1.0.11-jq-libvirt-sops-ssh` | [View](variants/v1.0.11-jq-libvirt-sops-ssh) |
-| `:v0.15.5` | [View](variants/v0.15.5) |
-| `:v0.15.5-jq-sops-ssh` | [View](variants/v0.15.5-jq-sops-ssh) |
-| `:v0.15.5-jq-libvirt-sops-ssh` | [View](variants/v0.15.5-jq-libvirt-sops-ssh) |
-| `:v0.14.11` | [View](variants/v0.14.11) |
-| `:v0.14.11-jq-sops-ssh` | [View](variants/v0.14.11-jq-sops-ssh) |
-| `:v0.14.11-jq-libvirt-sops-ssh` | [View](variants/v0.14.11-jq-libvirt-sops-ssh) |
-| `:v0.13.7` | [View](variants/v0.13.7) |
-| `:v0.13.7-jq-sops-ssh` | [View](variants/v0.13.7-jq-sops-ssh) |
-| `:v0.13.7-jq-libvirt-sops-ssh` | [View](variants/v0.13.7-jq-libvirt-sops-ssh) |
-| `:v0.12.31` | [View](variants/v0.12.31) |
-| `:v0.12.31-jq-sops-ssh` | [View](variants/v0.12.31-jq-sops-ssh) |
-| `:v0.12.31-jq-libvirt-sops-ssh` | [View](variants/v0.12.31-jq-libvirt-sops-ssh) |
-| `:v0.11.15` | [View](variants/v0.11.15) |
-| `:v0.11.15-jq-sops-ssh` | [View](variants/v0.11.15-jq-sops-ssh) |
-| `:v0.11.15-jq-libvirt-sops-ssh` | [View](variants/v0.11.15-jq-libvirt-sops-ssh) |
-| `:v0.10.8` | [View](variants/v0.10.8) |
-| `:v0.10.8-jq-sops-ssh` | [View](variants/v0.10.8-jq-sops-ssh) |
-| `:v0.10.8-jq-libvirt-sops-ssh` | [View](variants/v0.10.8-jq-libvirt-sops-ssh) |
-| `:v0.9.11` | [View](variants/v0.9.11) |
-| `:v0.9.11-jq-sops-ssh` | [View](variants/v0.9.11-jq-sops-ssh) |
-| `:v0.9.11-jq-libvirt-sops-ssh` | [View](variants/v0.9.11-jq-libvirt-sops-ssh) |
-| `:v0.8.8` | [View](variants/v0.8.8) |
-| `:v0.8.8-jq-sops-ssh` | [View](variants/v0.8.8-jq-sops-ssh) |
-| `:v0.8.8-jq-libvirt-sops-ssh` | [View](variants/v0.8.8-jq-libvirt-sops-ssh) |
+| `:1.5.7`, `:latest` | [View](variants/1.5.7) |
+| `:1.5.7-jq-sops-ssh` | [View](variants/1.5.7-jq-sops-ssh) |
+| `:1.5.7-jq-libvirt-sops-ssh` | [View](variants/1.5.7-jq-libvirt-sops-ssh) |
+| `:1.4.7` | [View](variants/1.4.7) |
+| `:1.4.7-jq-sops-ssh` | [View](variants/1.4.7-jq-sops-ssh) |
+| `:1.4.7-jq-libvirt-sops-ssh` | [View](variants/1.4.7-jq-libvirt-sops-ssh) |
+| `:1.3.10` | [View](variants/1.3.10) |
+| `:1.3.10-jq-sops-ssh` | [View](variants/1.3.10-jq-sops-ssh) |
+| `:1.3.10-jq-libvirt-sops-ssh` | [View](variants/1.3.10-jq-libvirt-sops-ssh) |
+| `:1.2.9` | [View](variants/1.2.9) |
+| `:1.2.9-jq-sops-ssh` | [View](variants/1.2.9-jq-sops-ssh) |
+| `:1.2.9-jq-libvirt-sops-ssh` | [View](variants/1.2.9-jq-libvirt-sops-ssh) |
+| `:1.1.9` | [View](variants/1.1.9) |
+| `:1.1.9-jq-sops-ssh` | [View](variants/1.1.9-jq-sops-ssh) |
+| `:1.1.9-jq-libvirt-sops-ssh` | [View](variants/1.1.9-jq-libvirt-sops-ssh) |
+| `:1.0.11` | [View](variants/1.0.11) |
+| `:1.0.11-jq-sops-ssh` | [View](variants/1.0.11-jq-sops-ssh) |
+| `:1.0.11-jq-libvirt-sops-ssh` | [View](variants/1.0.11-jq-libvirt-sops-ssh) |
+| `:0.15.5` | [View](variants/0.15.5) |
+| `:0.15.5-jq-sops-ssh` | [View](variants/0.15.5-jq-sops-ssh) |
+| `:0.15.5-jq-libvirt-sops-ssh` | [View](variants/0.15.5-jq-libvirt-sops-ssh) |
+| `:0.14.11` | [View](variants/0.14.11) |
+| `:0.14.11-jq-sops-ssh` | [View](variants/0.14.11-jq-sops-ssh) |
+| `:0.14.11-jq-libvirt-sops-ssh` | [View](variants/0.14.11-jq-libvirt-sops-ssh) |
+| `:0.13.7` | [View](variants/0.13.7) |
+| `:0.13.7-jq-sops-ssh` | [View](variants/0.13.7-jq-sops-ssh) |
+| `:0.13.7-jq-libvirt-sops-ssh` | [View](variants/0.13.7-jq-libvirt-sops-ssh) |
+| `:0.12.31` | [View](variants/0.12.31) |
+| `:0.12.31-jq-sops-ssh` | [View](variants/0.12.31-jq-sops-ssh) |
+| `:0.12.31-jq-libvirt-sops-ssh` | [View](variants/0.12.31-jq-libvirt-sops-ssh) |
+| `:0.11.15` | [View](variants/0.11.15) |
+| `:0.11.15-jq-sops-ssh` | [View](variants/0.11.15-jq-sops-ssh) |
+| `:0.11.15-jq-libvirt-sops-ssh` | [View](variants/0.11.15-jq-libvirt-sops-ssh) |
+| `:0.10.8` | [View](variants/0.10.8) |
+| `:0.10.8-jq-sops-ssh` | [View](variants/0.10.8-jq-sops-ssh) |
+| `:0.10.8-jq-libvirt-sops-ssh` | [View](variants/0.10.8-jq-libvirt-sops-ssh) |
+| `:0.9.11` | [View](variants/0.9.11) |
+| `:0.9.11-jq-sops-ssh` | [View](variants/0.9.11-jq-sops-ssh) |
+| `:0.9.11-jq-libvirt-sops-ssh` | [View](variants/0.9.11-jq-libvirt-sops-ssh) |
+| `:0.8.8` | [View](variants/0.8.8) |
+| `:0.8.8-jq-sops-ssh` | [View](variants/0.8.8-jq-sops-ssh) |
+| `:0.8.8-jq-libvirt-sops-ssh` | [View](variants/0.8.8-jq-libvirt-sops-ssh) |
 
 ## Development
 

--- a/Update-Versions.ps1
+++ b/Update-Versions.ps1
@@ -1,4 +1,4 @@
-# This script is to update versions in version.json, create PR(s) for each bumped version, merge PRs, and release
+# This script is to update versions in versions.json, create PR(s) for each bumped version, merge PRs, and release
 # It may be run manually or as a cron
 # Use -WhatIf for dry run
 [CmdletBinding(SupportsShouldProcess)]
@@ -53,4 +53,3 @@ try {
         Pop-Location
     }
 }
-

--- a/generate/definitions/VARIANTS.ps1
+++ b/generate/definitions/VARIANTS.ps1
@@ -38,7 +38,7 @@ $VARIANTS = @(
                 }
                 # Docker image tag. E.g. 'v1.5.2'
                 tag = @(
-                    "v$( $variant['package_version'] )"
+                    $variant['package_version']
                     $subVariant['components'] | ? { $_ }
                 ) -join '-'
                 tag_as_latest = if ($variant['package_version'] -eq $local:VARIANTS_MATRIX[0]['package_version'] -and $subVariant['components'].Count -eq 0) { $true } else { $false }

--- a/variants/0.10.8-jq-libvirt-sops-ssh/Dockerfile
+++ b/variants/0.10.8-jq-libvirt-sops-ssh/Dockerfile
@@ -1,0 +1,59 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=0.10.8; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/0.10.8/terraform_0.10.8_linux_386.zip; \
+            SHA256=a13ee4fb98fe0b219678934d72efaafd4b59fe10036a7de4cb769d51a9246ee5; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/0.10.8/terraform_0.10.8_linux_amd64.zip; \
+            SHA256=b786c0cf936e24145fad632efd0fe48c831558cc9e43c071fffd93f35e3150db; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/0.10.8/terraform_0.10.8_linux_arm.zip; \
+            SHA256=f0dd85b3fbdc0e873dd7cc59b96ce2d70467d8326575d79e853718b0baa79cc0; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/0.10.8/terraform_0.10.8_linux_arm.zip; \
+            SHA256=f0dd85b3fbdc0e873dd7cc59b96ce2d70467d8326575d79e853718b0baa79cc0; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+RUN apk add --no-cache jq
+
+RUN apk add --no-cache libvirt-client
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client sshpass
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/0.10.8-jq-sops-ssh/Dockerfile
+++ b/variants/0.10.8-jq-sops-ssh/Dockerfile
@@ -1,0 +1,57 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=0.10.8; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/0.10.8/terraform_0.10.8_linux_386.zip; \
+            SHA256=a13ee4fb98fe0b219678934d72efaafd4b59fe10036a7de4cb769d51a9246ee5; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/0.10.8/terraform_0.10.8_linux_amd64.zip; \
+            SHA256=b786c0cf936e24145fad632efd0fe48c831558cc9e43c071fffd93f35e3150db; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/0.10.8/terraform_0.10.8_linux_arm.zip; \
+            SHA256=f0dd85b3fbdc0e873dd7cc59b96ce2d70467d8326575d79e853718b0baa79cc0; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/0.10.8/terraform_0.10.8_linux_arm.zip; \
+            SHA256=f0dd85b3fbdc0e873dd7cc59b96ce2d70467d8326575d79e853718b0baa79cc0; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+RUN apk add --no-cache jq
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client sshpass
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/0.10.8/Dockerfile
+++ b/variants/0.10.8/Dockerfile
@@ -1,0 +1,45 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=0.10.8; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/0.10.8/terraform_0.10.8_linux_386.zip; \
+            SHA256=a13ee4fb98fe0b219678934d72efaafd4b59fe10036a7de4cb769d51a9246ee5; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/0.10.8/terraform_0.10.8_linux_amd64.zip; \
+            SHA256=b786c0cf936e24145fad632efd0fe48c831558cc9e43c071fffd93f35e3150db; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/0.10.8/terraform_0.10.8_linux_arm.zip; \
+            SHA256=f0dd85b3fbdc0e873dd7cc59b96ce2d70467d8326575d79e853718b0baa79cc0; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/0.10.8/terraform_0.10.8_linux_arm.zip; \
+            SHA256=f0dd85b3fbdc0e873dd7cc59b96ce2d70467d8326575d79e853718b0baa79cc0; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/0.11.15-jq-libvirt-sops-ssh/Dockerfile
+++ b/variants/0.11.15-jq-libvirt-sops-ssh/Dockerfile
@@ -1,0 +1,63 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=0.11.15; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/0.11.15/terraform_0.11.15_linux_386.zip; \
+            SHA256=83d55cb7979dac785e2fe409ab9142fd7c4f1c934090776c77c53f3683d404a3; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/0.11.15/terraform_0.11.15_linux_amd64.zip; \
+            SHA256=e6c8c884de6c353cf98252c5e11faf972d4b30b5d070ab5ff70eaf92660a5aac; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/0.11.15/terraform_0.11.15_linux_arm.zip; \
+            SHA256=45941c547e3c8f9822173fc2a4b20836db5693e91cbd4da195f414295f05ec53; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/0.11.15/terraform_0.11.15_linux_arm.zip; \
+            SHA256=45941c547e3c8f9822173fc2a4b20836db5693e91cbd4da195f414295f05ec53; \
+            ;; \
+        'aarch64') \
+            URL=https://releases.hashicorp.com/terraform/0.11.15/terraform_0.11.15_linux_arm64.zip; \
+            SHA256=99be59d7baf6744b496b77b92fe35fbfcd0395a1c2be328a87328406bc81d708; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+RUN apk add --no-cache jq
+
+RUN apk add --no-cache libvirt-client
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client sshpass
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/0.11.15-jq-sops-ssh/Dockerfile
+++ b/variants/0.11.15-jq-sops-ssh/Dockerfile
@@ -1,0 +1,61 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=0.11.15; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/0.11.15/terraform_0.11.15_linux_386.zip; \
+            SHA256=83d55cb7979dac785e2fe409ab9142fd7c4f1c934090776c77c53f3683d404a3; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/0.11.15/terraform_0.11.15_linux_amd64.zip; \
+            SHA256=e6c8c884de6c353cf98252c5e11faf972d4b30b5d070ab5ff70eaf92660a5aac; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/0.11.15/terraform_0.11.15_linux_arm.zip; \
+            SHA256=45941c547e3c8f9822173fc2a4b20836db5693e91cbd4da195f414295f05ec53; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/0.11.15/terraform_0.11.15_linux_arm.zip; \
+            SHA256=45941c547e3c8f9822173fc2a4b20836db5693e91cbd4da195f414295f05ec53; \
+            ;; \
+        'aarch64') \
+            URL=https://releases.hashicorp.com/terraform/0.11.15/terraform_0.11.15_linux_arm64.zip; \
+            SHA256=99be59d7baf6744b496b77b92fe35fbfcd0395a1c2be328a87328406bc81d708; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+RUN apk add --no-cache jq
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client sshpass
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/0.11.15/Dockerfile
+++ b/variants/0.11.15/Dockerfile
@@ -1,0 +1,49 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=0.11.15; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/0.11.15/terraform_0.11.15_linux_386.zip; \
+            SHA256=83d55cb7979dac785e2fe409ab9142fd7c4f1c934090776c77c53f3683d404a3; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/0.11.15/terraform_0.11.15_linux_amd64.zip; \
+            SHA256=e6c8c884de6c353cf98252c5e11faf972d4b30b5d070ab5ff70eaf92660a5aac; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/0.11.15/terraform_0.11.15_linux_arm.zip; \
+            SHA256=45941c547e3c8f9822173fc2a4b20836db5693e91cbd4da195f414295f05ec53; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/0.11.15/terraform_0.11.15_linux_arm.zip; \
+            SHA256=45941c547e3c8f9822173fc2a4b20836db5693e91cbd4da195f414295f05ec53; \
+            ;; \
+        'aarch64') \
+            URL=https://releases.hashicorp.com/terraform/0.11.15/terraform_0.11.15_linux_arm64.zip; \
+            SHA256=99be59d7baf6744b496b77b92fe35fbfcd0395a1c2be328a87328406bc81d708; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/0.12.31-jq-libvirt-sops-ssh/Dockerfile
+++ b/variants/0.12.31-jq-libvirt-sops-ssh/Dockerfile
@@ -1,0 +1,63 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=0.12.31; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/0.12.31/terraform_0.12.31_linux_386.zip; \
+            SHA256=abdd13b29cac315900246bf8ebff19040dbc1ae6ce99c1348e1bc59ba04241f1; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/0.12.31/terraform_0.12.31_linux_amd64.zip; \
+            SHA256=e5eeba803bc7d8d0cae7ef04ba7c3541c0abd8f9e934a5e3297bf738b31c5c6d; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/0.12.31/terraform_0.12.31_linux_arm.zip; \
+            SHA256=f5894ebdc8aceb12da840045508c362eb0f923e4b5115bb601fefa8f1f1d3cb9; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/0.12.31/terraform_0.12.31_linux_arm.zip; \
+            SHA256=f5894ebdc8aceb12da840045508c362eb0f923e4b5115bb601fefa8f1f1d3cb9; \
+            ;; \
+        'aarch64') \
+            URL=https://releases.hashicorp.com/terraform/0.12.31/terraform_0.12.31_linux_arm64.zip; \
+            SHA256=737205d76f576e47a5d7a41e506b2ec8eb7a0f6a0b3b3b0a8de59551c2f2b77f; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+RUN apk add --no-cache jq
+
+RUN apk add --no-cache libvirt-client
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client sshpass
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/0.12.31-jq-sops-ssh/Dockerfile
+++ b/variants/0.12.31-jq-sops-ssh/Dockerfile
@@ -1,0 +1,61 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=0.12.31; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/0.12.31/terraform_0.12.31_linux_386.zip; \
+            SHA256=abdd13b29cac315900246bf8ebff19040dbc1ae6ce99c1348e1bc59ba04241f1; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/0.12.31/terraform_0.12.31_linux_amd64.zip; \
+            SHA256=e5eeba803bc7d8d0cae7ef04ba7c3541c0abd8f9e934a5e3297bf738b31c5c6d; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/0.12.31/terraform_0.12.31_linux_arm.zip; \
+            SHA256=f5894ebdc8aceb12da840045508c362eb0f923e4b5115bb601fefa8f1f1d3cb9; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/0.12.31/terraform_0.12.31_linux_arm.zip; \
+            SHA256=f5894ebdc8aceb12da840045508c362eb0f923e4b5115bb601fefa8f1f1d3cb9; \
+            ;; \
+        'aarch64') \
+            URL=https://releases.hashicorp.com/terraform/0.12.31/terraform_0.12.31_linux_arm64.zip; \
+            SHA256=737205d76f576e47a5d7a41e506b2ec8eb7a0f6a0b3b3b0a8de59551c2f2b77f; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+RUN apk add --no-cache jq
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client sshpass
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/0.12.31/Dockerfile
+++ b/variants/0.12.31/Dockerfile
@@ -1,0 +1,49 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=0.12.31; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/0.12.31/terraform_0.12.31_linux_386.zip; \
+            SHA256=abdd13b29cac315900246bf8ebff19040dbc1ae6ce99c1348e1bc59ba04241f1; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/0.12.31/terraform_0.12.31_linux_amd64.zip; \
+            SHA256=e5eeba803bc7d8d0cae7ef04ba7c3541c0abd8f9e934a5e3297bf738b31c5c6d; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/0.12.31/terraform_0.12.31_linux_arm.zip; \
+            SHA256=f5894ebdc8aceb12da840045508c362eb0f923e4b5115bb601fefa8f1f1d3cb9; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/0.12.31/terraform_0.12.31_linux_arm.zip; \
+            SHA256=f5894ebdc8aceb12da840045508c362eb0f923e4b5115bb601fefa8f1f1d3cb9; \
+            ;; \
+        'aarch64') \
+            URL=https://releases.hashicorp.com/terraform/0.12.31/terraform_0.12.31_linux_arm64.zip; \
+            SHA256=737205d76f576e47a5d7a41e506b2ec8eb7a0f6a0b3b3b0a8de59551c2f2b77f; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/0.13.7-jq-libvirt-sops-ssh/Dockerfile
+++ b/variants/0.13.7-jq-libvirt-sops-ssh/Dockerfile
@@ -1,0 +1,63 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=0.13.7; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/0.13.7/terraform_0.13.7_linux_386.zip; \
+            SHA256=90df3c9e8a9facf93631c6d338b867db391b435a39a1ca0a02ae4908f01dc2ea; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/0.13.7/terraform_0.13.7_linux_amd64.zip; \
+            SHA256=4a52886e019b4fdad2439da5ff43388bbcc6cce9784fde32c53dcd0e28ca9957; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/0.13.7/terraform_0.13.7_linux_arm.zip; \
+            SHA256=9af803e215be58ed6cf89e9d22b826d7b3634bef70dc94abc13fdd2bd85b1f80; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/0.13.7/terraform_0.13.7_linux_arm.zip; \
+            SHA256=9af803e215be58ed6cf89e9d22b826d7b3634bef70dc94abc13fdd2bd85b1f80; \
+            ;; \
+        'aarch64') \
+            URL=https://releases.hashicorp.com/terraform/0.13.7/terraform_0.13.7_linux_arm64.zip; \
+            SHA256=59b85b7b4b4b2939a4c05db905100dd8808f8df8b5a0e8a00a26e7dcf0c4a2be; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+RUN apk add --no-cache jq
+
+RUN apk add --no-cache libvirt-client
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client sshpass
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/0.13.7-jq-sops-ssh/Dockerfile
+++ b/variants/0.13.7-jq-sops-ssh/Dockerfile
@@ -1,0 +1,61 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=0.13.7; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/0.13.7/terraform_0.13.7_linux_386.zip; \
+            SHA256=90df3c9e8a9facf93631c6d338b867db391b435a39a1ca0a02ae4908f01dc2ea; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/0.13.7/terraform_0.13.7_linux_amd64.zip; \
+            SHA256=4a52886e019b4fdad2439da5ff43388bbcc6cce9784fde32c53dcd0e28ca9957; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/0.13.7/terraform_0.13.7_linux_arm.zip; \
+            SHA256=9af803e215be58ed6cf89e9d22b826d7b3634bef70dc94abc13fdd2bd85b1f80; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/0.13.7/terraform_0.13.7_linux_arm.zip; \
+            SHA256=9af803e215be58ed6cf89e9d22b826d7b3634bef70dc94abc13fdd2bd85b1f80; \
+            ;; \
+        'aarch64') \
+            URL=https://releases.hashicorp.com/terraform/0.13.7/terraform_0.13.7_linux_arm64.zip; \
+            SHA256=59b85b7b4b4b2939a4c05db905100dd8808f8df8b5a0e8a00a26e7dcf0c4a2be; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+RUN apk add --no-cache jq
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client sshpass
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/0.13.7/Dockerfile
+++ b/variants/0.13.7/Dockerfile
@@ -1,0 +1,49 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=0.13.7; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/0.13.7/terraform_0.13.7_linux_386.zip; \
+            SHA256=90df3c9e8a9facf93631c6d338b867db391b435a39a1ca0a02ae4908f01dc2ea; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/0.13.7/terraform_0.13.7_linux_amd64.zip; \
+            SHA256=4a52886e019b4fdad2439da5ff43388bbcc6cce9784fde32c53dcd0e28ca9957; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/0.13.7/terraform_0.13.7_linux_arm.zip; \
+            SHA256=9af803e215be58ed6cf89e9d22b826d7b3634bef70dc94abc13fdd2bd85b1f80; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/0.13.7/terraform_0.13.7_linux_arm.zip; \
+            SHA256=9af803e215be58ed6cf89e9d22b826d7b3634bef70dc94abc13fdd2bd85b1f80; \
+            ;; \
+        'aarch64') \
+            URL=https://releases.hashicorp.com/terraform/0.13.7/terraform_0.13.7_linux_arm64.zip; \
+            SHA256=59b85b7b4b4b2939a4c05db905100dd8808f8df8b5a0e8a00a26e7dcf0c4a2be; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/0.14.11-jq-libvirt-sops-ssh/Dockerfile
+++ b/variants/0.14.11-jq-libvirt-sops-ssh/Dockerfile
@@ -1,0 +1,63 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=0.14.11; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/0.14.11/terraform_0.14.11_linux_386.zip; \
+            SHA256=27aa3d1aacaa1aa64ed743b44995b47e3eebe2ded14b221f4dee9f98dd8350ff; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/0.14.11/terraform_0.14.11_linux_amd64.zip; \
+            SHA256=171ef5a4691b6f86eab524feaf9a52d5221c875478bd63dd7e55fef3939f7fd4; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/0.14.11/terraform_0.14.11_linux_arm.zip; \
+            SHA256=4f9f628e58998f50d8c8bc96b4f8feb3bf13fc7ae54c47c234526ee48f7514d9; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/0.14.11/terraform_0.14.11_linux_arm.zip; \
+            SHA256=4f9f628e58998f50d8c8bc96b4f8feb3bf13fc7ae54c47c234526ee48f7514d9; \
+            ;; \
+        'aarch64') \
+            URL=https://releases.hashicorp.com/terraform/0.14.11/terraform_0.14.11_linux_arm64.zip; \
+            SHA256=602813ce2afe1e874807a66fc2e28b7cb90d9381b76a5d7b7f0ec9aa768eb2bc; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+RUN apk add --no-cache jq
+
+RUN apk add --no-cache libvirt-client
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client sshpass
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/0.14.11-jq-sops-ssh/Dockerfile
+++ b/variants/0.14.11-jq-sops-ssh/Dockerfile
@@ -1,0 +1,61 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=0.14.11; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/0.14.11/terraform_0.14.11_linux_386.zip; \
+            SHA256=27aa3d1aacaa1aa64ed743b44995b47e3eebe2ded14b221f4dee9f98dd8350ff; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/0.14.11/terraform_0.14.11_linux_amd64.zip; \
+            SHA256=171ef5a4691b6f86eab524feaf9a52d5221c875478bd63dd7e55fef3939f7fd4; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/0.14.11/terraform_0.14.11_linux_arm.zip; \
+            SHA256=4f9f628e58998f50d8c8bc96b4f8feb3bf13fc7ae54c47c234526ee48f7514d9; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/0.14.11/terraform_0.14.11_linux_arm.zip; \
+            SHA256=4f9f628e58998f50d8c8bc96b4f8feb3bf13fc7ae54c47c234526ee48f7514d9; \
+            ;; \
+        'aarch64') \
+            URL=https://releases.hashicorp.com/terraform/0.14.11/terraform_0.14.11_linux_arm64.zip; \
+            SHA256=602813ce2afe1e874807a66fc2e28b7cb90d9381b76a5d7b7f0ec9aa768eb2bc; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+RUN apk add --no-cache jq
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client sshpass
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/0.14.11/Dockerfile
+++ b/variants/0.14.11/Dockerfile
@@ -1,0 +1,49 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=0.14.11; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/0.14.11/terraform_0.14.11_linux_386.zip; \
+            SHA256=27aa3d1aacaa1aa64ed743b44995b47e3eebe2ded14b221f4dee9f98dd8350ff; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/0.14.11/terraform_0.14.11_linux_amd64.zip; \
+            SHA256=171ef5a4691b6f86eab524feaf9a52d5221c875478bd63dd7e55fef3939f7fd4; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/0.14.11/terraform_0.14.11_linux_arm.zip; \
+            SHA256=4f9f628e58998f50d8c8bc96b4f8feb3bf13fc7ae54c47c234526ee48f7514d9; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/0.14.11/terraform_0.14.11_linux_arm.zip; \
+            SHA256=4f9f628e58998f50d8c8bc96b4f8feb3bf13fc7ae54c47c234526ee48f7514d9; \
+            ;; \
+        'aarch64') \
+            URL=https://releases.hashicorp.com/terraform/0.14.11/terraform_0.14.11_linux_arm64.zip; \
+            SHA256=602813ce2afe1e874807a66fc2e28b7cb90d9381b76a5d7b7f0ec9aa768eb2bc; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/0.15.5-jq-libvirt-sops-ssh/Dockerfile
+++ b/variants/0.15.5-jq-libvirt-sops-ssh/Dockerfile
@@ -1,0 +1,63 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=0.15.5; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/0.15.5/terraform_0.15.5_linux_386.zip; \
+            SHA256=0155d6844ae554021f8ca58b57f1e6dda7d88b6cf1d02113f3a3480e178c46b9; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/0.15.5/terraform_0.15.5_linux_amd64.zip; \
+            SHA256=3b144499e08c245a8039027eb2b84c0495e119f57d79e8fb605864bb48897a7d; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/0.15.5/terraform_0.15.5_linux_arm.zip; \
+            SHA256=3122e7ac6353d488d766ac84379139e3d14f564fbe61f4b069f7584ca9c29e01; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/0.15.5/terraform_0.15.5_linux_arm.zip; \
+            SHA256=3122e7ac6353d488d766ac84379139e3d14f564fbe61f4b069f7584ca9c29e01; \
+            ;; \
+        'aarch64') \
+            URL=https://releases.hashicorp.com/terraform/0.15.5/terraform_0.15.5_linux_arm64.zip; \
+            SHA256=bc5a9d734010e55fb374a4cab9eb0539139d34fd84f58d2242573f275f67fc13; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+RUN apk add --no-cache jq
+
+RUN apk add --no-cache libvirt-client
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client sshpass
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/0.15.5-jq-sops-ssh/Dockerfile
+++ b/variants/0.15.5-jq-sops-ssh/Dockerfile
@@ -1,0 +1,61 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=0.15.5; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/0.15.5/terraform_0.15.5_linux_386.zip; \
+            SHA256=0155d6844ae554021f8ca58b57f1e6dda7d88b6cf1d02113f3a3480e178c46b9; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/0.15.5/terraform_0.15.5_linux_amd64.zip; \
+            SHA256=3b144499e08c245a8039027eb2b84c0495e119f57d79e8fb605864bb48897a7d; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/0.15.5/terraform_0.15.5_linux_arm.zip; \
+            SHA256=3122e7ac6353d488d766ac84379139e3d14f564fbe61f4b069f7584ca9c29e01; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/0.15.5/terraform_0.15.5_linux_arm.zip; \
+            SHA256=3122e7ac6353d488d766ac84379139e3d14f564fbe61f4b069f7584ca9c29e01; \
+            ;; \
+        'aarch64') \
+            URL=https://releases.hashicorp.com/terraform/0.15.5/terraform_0.15.5_linux_arm64.zip; \
+            SHA256=bc5a9d734010e55fb374a4cab9eb0539139d34fd84f58d2242573f275f67fc13; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+RUN apk add --no-cache jq
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client sshpass
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/0.15.5/Dockerfile
+++ b/variants/0.15.5/Dockerfile
@@ -1,0 +1,49 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=0.15.5; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/0.15.5/terraform_0.15.5_linux_386.zip; \
+            SHA256=0155d6844ae554021f8ca58b57f1e6dda7d88b6cf1d02113f3a3480e178c46b9; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/0.15.5/terraform_0.15.5_linux_amd64.zip; \
+            SHA256=3b144499e08c245a8039027eb2b84c0495e119f57d79e8fb605864bb48897a7d; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/0.15.5/terraform_0.15.5_linux_arm.zip; \
+            SHA256=3122e7ac6353d488d766ac84379139e3d14f564fbe61f4b069f7584ca9c29e01; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/0.15.5/terraform_0.15.5_linux_arm.zip; \
+            SHA256=3122e7ac6353d488d766ac84379139e3d14f564fbe61f4b069f7584ca9c29e01; \
+            ;; \
+        'aarch64') \
+            URL=https://releases.hashicorp.com/terraform/0.15.5/terraform_0.15.5_linux_arm64.zip; \
+            SHA256=bc5a9d734010e55fb374a4cab9eb0539139d34fd84f58d2242573f275f67fc13; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/0.8.8-jq-libvirt-sops-ssh/Dockerfile
+++ b/variants/0.8.8-jq-libvirt-sops-ssh/Dockerfile
@@ -1,0 +1,59 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=0.8.8; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/0.8.8/terraform_0.8.8_linux_386.zip; \
+            SHA256=d483dd90baf752e18af030738a68540e8237ceee5a9ce6f3882cfa7efda7ac1b; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/0.8.8/terraform_0.8.8_linux_amd64.zip; \
+            SHA256=403d65b8a728b8dffcdd829262b57949bce9748b91f2e82dfd6d61692236b376; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/0.8.8/terraform_0.8.8_linux_arm.zip; \
+            SHA256=7591914ba8a64db00b8fc8ac9379643a519a2f796ffe2cc424790a7d1bd99763; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/0.8.8/terraform_0.8.8_linux_arm.zip; \
+            SHA256=7591914ba8a64db00b8fc8ac9379643a519a2f796ffe2cc424790a7d1bd99763; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+RUN apk add --no-cache jq
+
+RUN apk add --no-cache libvirt-client
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client sshpass
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/0.8.8-jq-sops-ssh/Dockerfile
+++ b/variants/0.8.8-jq-sops-ssh/Dockerfile
@@ -1,0 +1,57 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=0.8.8; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/0.8.8/terraform_0.8.8_linux_386.zip; \
+            SHA256=d483dd90baf752e18af030738a68540e8237ceee5a9ce6f3882cfa7efda7ac1b; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/0.8.8/terraform_0.8.8_linux_amd64.zip; \
+            SHA256=403d65b8a728b8dffcdd829262b57949bce9748b91f2e82dfd6d61692236b376; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/0.8.8/terraform_0.8.8_linux_arm.zip; \
+            SHA256=7591914ba8a64db00b8fc8ac9379643a519a2f796ffe2cc424790a7d1bd99763; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/0.8.8/terraform_0.8.8_linux_arm.zip; \
+            SHA256=7591914ba8a64db00b8fc8ac9379643a519a2f796ffe2cc424790a7d1bd99763; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+RUN apk add --no-cache jq
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client sshpass
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/0.8.8/Dockerfile
+++ b/variants/0.8.8/Dockerfile
@@ -1,0 +1,45 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=0.8.8; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/0.8.8/terraform_0.8.8_linux_386.zip; \
+            SHA256=d483dd90baf752e18af030738a68540e8237ceee5a9ce6f3882cfa7efda7ac1b; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/0.8.8/terraform_0.8.8_linux_amd64.zip; \
+            SHA256=403d65b8a728b8dffcdd829262b57949bce9748b91f2e82dfd6d61692236b376; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/0.8.8/terraform_0.8.8_linux_arm.zip; \
+            SHA256=7591914ba8a64db00b8fc8ac9379643a519a2f796ffe2cc424790a7d1bd99763; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/0.8.8/terraform_0.8.8_linux_arm.zip; \
+            SHA256=7591914ba8a64db00b8fc8ac9379643a519a2f796ffe2cc424790a7d1bd99763; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/0.9.11-jq-libvirt-sops-ssh/Dockerfile
+++ b/variants/0.9.11-jq-libvirt-sops-ssh/Dockerfile
@@ -1,0 +1,59 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=0.9.11; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/0.9.11/terraform_0.9.11_linux_386.zip; \
+            SHA256=5c4b95c0d4967051763ded642f868d4fd7783eb49d6a07f57c1d2e0de0e1cdf4; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/0.9.11/terraform_0.9.11_linux_amd64.zip; \
+            SHA256=804d31cfa5fee5c2b1bff7816b64f0e26b1d766ac347c67091adccc2626e16f3; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/0.9.11/terraform_0.9.11_linux_arm.zip; \
+            SHA256=4f9ae0f2135dd98d752adb36b251c616486ec1dcf709a9ceda8e04787b287023; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/0.9.11/terraform_0.9.11_linux_arm.zip; \
+            SHA256=4f9ae0f2135dd98d752adb36b251c616486ec1dcf709a9ceda8e04787b287023; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+RUN apk add --no-cache jq
+
+RUN apk add --no-cache libvirt-client
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client sshpass
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/0.9.11-jq-sops-ssh/Dockerfile
+++ b/variants/0.9.11-jq-sops-ssh/Dockerfile
@@ -1,0 +1,57 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=0.9.11; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/0.9.11/terraform_0.9.11_linux_386.zip; \
+            SHA256=5c4b95c0d4967051763ded642f868d4fd7783eb49d6a07f57c1d2e0de0e1cdf4; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/0.9.11/terraform_0.9.11_linux_amd64.zip; \
+            SHA256=804d31cfa5fee5c2b1bff7816b64f0e26b1d766ac347c67091adccc2626e16f3; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/0.9.11/terraform_0.9.11_linux_arm.zip; \
+            SHA256=4f9ae0f2135dd98d752adb36b251c616486ec1dcf709a9ceda8e04787b287023; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/0.9.11/terraform_0.9.11_linux_arm.zip; \
+            SHA256=4f9ae0f2135dd98d752adb36b251c616486ec1dcf709a9ceda8e04787b287023; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+RUN apk add --no-cache jq
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client sshpass
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/0.9.11/Dockerfile
+++ b/variants/0.9.11/Dockerfile
@@ -1,0 +1,45 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=0.9.11; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/0.9.11/terraform_0.9.11_linux_386.zip; \
+            SHA256=5c4b95c0d4967051763ded642f868d4fd7783eb49d6a07f57c1d2e0de0e1cdf4; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/0.9.11/terraform_0.9.11_linux_amd64.zip; \
+            SHA256=804d31cfa5fee5c2b1bff7816b64f0e26b1d766ac347c67091adccc2626e16f3; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/0.9.11/terraform_0.9.11_linux_arm.zip; \
+            SHA256=4f9ae0f2135dd98d752adb36b251c616486ec1dcf709a9ceda8e04787b287023; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/0.9.11/terraform_0.9.11_linux_arm.zip; \
+            SHA256=4f9ae0f2135dd98d752adb36b251c616486ec1dcf709a9ceda8e04787b287023; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/1.0.11-jq-libvirt-sops-ssh/Dockerfile
+++ b/variants/1.0.11-jq-libvirt-sops-ssh/Dockerfile
@@ -1,0 +1,63 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=1.0.11; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/1.0.11/terraform_1.0.11_linux_386.zip; \
+            SHA256=143d01fb4bacf8dd97918fb2e1ad38d4489fbe9f5669a32d0adb69ce3e9aecea; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/1.0.11/terraform_1.0.11_linux_amd64.zip; \
+            SHA256=eeb46091a42dc303c3a3c300640c7774ab25cbee5083dafa5fd83b54c8aca664; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/1.0.11/terraform_1.0.11_linux_arm.zip; \
+            SHA256=cce11dd382af930ef20234d84695d187bf869e366e7d91337068719ff1a7c843; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/1.0.11/terraform_1.0.11_linux_arm.zip; \
+            SHA256=cce11dd382af930ef20234d84695d187bf869e366e7d91337068719ff1a7c843; \
+            ;; \
+        'aarch64') \
+            URL=https://releases.hashicorp.com/terraform/1.0.11/terraform_1.0.11_linux_arm64.zip; \
+            SHA256=30c650f4bc218659d43e07d911c00f08e420664a3d12c812228e66f666758645; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+RUN apk add --no-cache jq
+
+RUN apk add --no-cache libvirt-client
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client sshpass
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/1.0.11-jq-sops-ssh/Dockerfile
+++ b/variants/1.0.11-jq-sops-ssh/Dockerfile
@@ -1,0 +1,61 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=1.0.11; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/1.0.11/terraform_1.0.11_linux_386.zip; \
+            SHA256=143d01fb4bacf8dd97918fb2e1ad38d4489fbe9f5669a32d0adb69ce3e9aecea; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/1.0.11/terraform_1.0.11_linux_amd64.zip; \
+            SHA256=eeb46091a42dc303c3a3c300640c7774ab25cbee5083dafa5fd83b54c8aca664; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/1.0.11/terraform_1.0.11_linux_arm.zip; \
+            SHA256=cce11dd382af930ef20234d84695d187bf869e366e7d91337068719ff1a7c843; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/1.0.11/terraform_1.0.11_linux_arm.zip; \
+            SHA256=cce11dd382af930ef20234d84695d187bf869e366e7d91337068719ff1a7c843; \
+            ;; \
+        'aarch64') \
+            URL=https://releases.hashicorp.com/terraform/1.0.11/terraform_1.0.11_linux_arm64.zip; \
+            SHA256=30c650f4bc218659d43e07d911c00f08e420664a3d12c812228e66f666758645; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+RUN apk add --no-cache jq
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client sshpass
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/1.0.11/Dockerfile
+++ b/variants/1.0.11/Dockerfile
@@ -1,0 +1,49 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=1.0.11; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/1.0.11/terraform_1.0.11_linux_386.zip; \
+            SHA256=143d01fb4bacf8dd97918fb2e1ad38d4489fbe9f5669a32d0adb69ce3e9aecea; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/1.0.11/terraform_1.0.11_linux_amd64.zip; \
+            SHA256=eeb46091a42dc303c3a3c300640c7774ab25cbee5083dafa5fd83b54c8aca664; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/1.0.11/terraform_1.0.11_linux_arm.zip; \
+            SHA256=cce11dd382af930ef20234d84695d187bf869e366e7d91337068719ff1a7c843; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/1.0.11/terraform_1.0.11_linux_arm.zip; \
+            SHA256=cce11dd382af930ef20234d84695d187bf869e366e7d91337068719ff1a7c843; \
+            ;; \
+        'aarch64') \
+            URL=https://releases.hashicorp.com/terraform/1.0.11/terraform_1.0.11_linux_arm64.zip; \
+            SHA256=30c650f4bc218659d43e07d911c00f08e420664a3d12c812228e66f666758645; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/1.1.9-jq-libvirt-sops-ssh/Dockerfile
+++ b/variants/1.1.9-jq-libvirt-sops-ssh/Dockerfile
@@ -1,0 +1,63 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=1.1.9; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/1.1.9/terraform_1.1.9_linux_386.zip; \
+            SHA256=a29a5c069e1712753ed553f7c6e63f1cd35caefee73496210461c05158b836b4; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/1.1.9/terraform_1.1.9_linux_amd64.zip; \
+            SHA256=9d2d8a89f5cc8bc1c06cb6f34ce76ec4b99184b07eb776f8b39183b513d7798a; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/1.1.9/terraform_1.1.9_linux_arm.zip; \
+            SHA256=800eee18651b5e552772c60fc1b5eb00cdcefddf11969412203c6de6189aa10a; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/1.1.9/terraform_1.1.9_linux_arm.zip; \
+            SHA256=800eee18651b5e552772c60fc1b5eb00cdcefddf11969412203c6de6189aa10a; \
+            ;; \
+        'aarch64') \
+            URL=https://releases.hashicorp.com/terraform/1.1.9/terraform_1.1.9_linux_arm64.zip; \
+            SHA256=e8a09d1fe5a68ed75e5fabe26c609ad12a7e459002dea6543f1084993b87a266; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+RUN apk add --no-cache jq
+
+RUN apk add --no-cache libvirt-client
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client sshpass
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/1.1.9-jq-sops-ssh/Dockerfile
+++ b/variants/1.1.9-jq-sops-ssh/Dockerfile
@@ -1,0 +1,61 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=1.1.9; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/1.1.9/terraform_1.1.9_linux_386.zip; \
+            SHA256=a29a5c069e1712753ed553f7c6e63f1cd35caefee73496210461c05158b836b4; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/1.1.9/terraform_1.1.9_linux_amd64.zip; \
+            SHA256=9d2d8a89f5cc8bc1c06cb6f34ce76ec4b99184b07eb776f8b39183b513d7798a; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/1.1.9/terraform_1.1.9_linux_arm.zip; \
+            SHA256=800eee18651b5e552772c60fc1b5eb00cdcefddf11969412203c6de6189aa10a; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/1.1.9/terraform_1.1.9_linux_arm.zip; \
+            SHA256=800eee18651b5e552772c60fc1b5eb00cdcefddf11969412203c6de6189aa10a; \
+            ;; \
+        'aarch64') \
+            URL=https://releases.hashicorp.com/terraform/1.1.9/terraform_1.1.9_linux_arm64.zip; \
+            SHA256=e8a09d1fe5a68ed75e5fabe26c609ad12a7e459002dea6543f1084993b87a266; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+RUN apk add --no-cache jq
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client sshpass
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/1.1.9/Dockerfile
+++ b/variants/1.1.9/Dockerfile
@@ -1,0 +1,49 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=1.1.9; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/1.1.9/terraform_1.1.9_linux_386.zip; \
+            SHA256=a29a5c069e1712753ed553f7c6e63f1cd35caefee73496210461c05158b836b4; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/1.1.9/terraform_1.1.9_linux_amd64.zip; \
+            SHA256=9d2d8a89f5cc8bc1c06cb6f34ce76ec4b99184b07eb776f8b39183b513d7798a; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/1.1.9/terraform_1.1.9_linux_arm.zip; \
+            SHA256=800eee18651b5e552772c60fc1b5eb00cdcefddf11969412203c6de6189aa10a; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/1.1.9/terraform_1.1.9_linux_arm.zip; \
+            SHA256=800eee18651b5e552772c60fc1b5eb00cdcefddf11969412203c6de6189aa10a; \
+            ;; \
+        'aarch64') \
+            URL=https://releases.hashicorp.com/terraform/1.1.9/terraform_1.1.9_linux_arm64.zip; \
+            SHA256=e8a09d1fe5a68ed75e5fabe26c609ad12a7e459002dea6543f1084993b87a266; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/1.2.9-jq-libvirt-sops-ssh/Dockerfile
+++ b/variants/1.2.9-jq-libvirt-sops-ssh/Dockerfile
@@ -1,0 +1,63 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=1.2.9; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/1.2.9/terraform_1.2.9_linux_386.zip; \
+            SHA256=f9028c4834cd3f2d20975e8ae9897e48f811bb8d494b734a87dab0d3968039c7; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/1.2.9/terraform_1.2.9_linux_amd64.zip; \
+            SHA256=0e0fc38641addac17103122e1953a9afad764a90e74daf4ff8ceeba4e362f2fb; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/1.2.9/terraform_1.2.9_linux_arm.zip; \
+            SHA256=647a69acf01b3cac829f4436e8095d927ee6732cd6c076e24674a3c09326aad2; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/1.2.9/terraform_1.2.9_linux_arm.zip; \
+            SHA256=647a69acf01b3cac829f4436e8095d927ee6732cd6c076e24674a3c09326aad2; \
+            ;; \
+        'aarch64') \
+            URL=https://releases.hashicorp.com/terraform/1.2.9/terraform_1.2.9_linux_arm64.zip; \
+            SHA256=6da7bf01f5a72e61255c2d80eddeba51998e2bb1f50a6d81b0d3b71e70e18531; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+RUN apk add --no-cache jq
+
+RUN apk add --no-cache libvirt-client
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client sshpass
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/1.2.9-jq-sops-ssh/Dockerfile
+++ b/variants/1.2.9-jq-sops-ssh/Dockerfile
@@ -1,0 +1,61 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=1.2.9; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/1.2.9/terraform_1.2.9_linux_386.zip; \
+            SHA256=f9028c4834cd3f2d20975e8ae9897e48f811bb8d494b734a87dab0d3968039c7; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/1.2.9/terraform_1.2.9_linux_amd64.zip; \
+            SHA256=0e0fc38641addac17103122e1953a9afad764a90e74daf4ff8ceeba4e362f2fb; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/1.2.9/terraform_1.2.9_linux_arm.zip; \
+            SHA256=647a69acf01b3cac829f4436e8095d927ee6732cd6c076e24674a3c09326aad2; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/1.2.9/terraform_1.2.9_linux_arm.zip; \
+            SHA256=647a69acf01b3cac829f4436e8095d927ee6732cd6c076e24674a3c09326aad2; \
+            ;; \
+        'aarch64') \
+            URL=https://releases.hashicorp.com/terraform/1.2.9/terraform_1.2.9_linux_arm64.zip; \
+            SHA256=6da7bf01f5a72e61255c2d80eddeba51998e2bb1f50a6d81b0d3b71e70e18531; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+RUN apk add --no-cache jq
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client sshpass
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/1.2.9/Dockerfile
+++ b/variants/1.2.9/Dockerfile
@@ -1,0 +1,49 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=1.2.9; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/1.2.9/terraform_1.2.9_linux_386.zip; \
+            SHA256=f9028c4834cd3f2d20975e8ae9897e48f811bb8d494b734a87dab0d3968039c7; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/1.2.9/terraform_1.2.9_linux_amd64.zip; \
+            SHA256=0e0fc38641addac17103122e1953a9afad764a90e74daf4ff8ceeba4e362f2fb; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/1.2.9/terraform_1.2.9_linux_arm.zip; \
+            SHA256=647a69acf01b3cac829f4436e8095d927ee6732cd6c076e24674a3c09326aad2; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/1.2.9/terraform_1.2.9_linux_arm.zip; \
+            SHA256=647a69acf01b3cac829f4436e8095d927ee6732cd6c076e24674a3c09326aad2; \
+            ;; \
+        'aarch64') \
+            URL=https://releases.hashicorp.com/terraform/1.2.9/terraform_1.2.9_linux_arm64.zip; \
+            SHA256=6da7bf01f5a72e61255c2d80eddeba51998e2bb1f50a6d81b0d3b71e70e18531; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/1.3.10-jq-libvirt-sops-ssh/Dockerfile
+++ b/variants/1.3.10-jq-libvirt-sops-ssh/Dockerfile
@@ -1,0 +1,63 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=1.3.10; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/1.3.10/terraform_1.3.10_linux_386.zip; \
+            SHA256=b8a3db560c9b7369066c423f302d00bf0643b7a89748948b778476e3dad5dcd2; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/1.3.10/terraform_1.3.10_linux_amd64.zip; \
+            SHA256=2e3931c3db6999cdd4c7e55227cb877c6946d1f52923d7d057036d2827311402; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/1.3.10/terraform_1.3.10_linux_arm.zip; \
+            SHA256=5b51a3a601af0c7b3e2bac88fb01e9127d47e241d8b16e52831c3a20e79e1c39; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/1.3.10/terraform_1.3.10_linux_arm.zip; \
+            SHA256=5b51a3a601af0c7b3e2bac88fb01e9127d47e241d8b16e52831c3a20e79e1c39; \
+            ;; \
+        'aarch64') \
+            URL=https://releases.hashicorp.com/terraform/1.3.10/terraform_1.3.10_linux_arm64.zip; \
+            SHA256=26dbff9a7d5de4ae0b3972fd62ff4784af6d5887833a91a88a013255c9069117; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+RUN apk add --no-cache jq
+
+RUN apk add --no-cache libvirt-client
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client sshpass
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/1.3.10-jq-sops-ssh/Dockerfile
+++ b/variants/1.3.10-jq-sops-ssh/Dockerfile
@@ -1,0 +1,61 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=1.3.10; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/1.3.10/terraform_1.3.10_linux_386.zip; \
+            SHA256=b8a3db560c9b7369066c423f302d00bf0643b7a89748948b778476e3dad5dcd2; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/1.3.10/terraform_1.3.10_linux_amd64.zip; \
+            SHA256=2e3931c3db6999cdd4c7e55227cb877c6946d1f52923d7d057036d2827311402; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/1.3.10/terraform_1.3.10_linux_arm.zip; \
+            SHA256=5b51a3a601af0c7b3e2bac88fb01e9127d47e241d8b16e52831c3a20e79e1c39; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/1.3.10/terraform_1.3.10_linux_arm.zip; \
+            SHA256=5b51a3a601af0c7b3e2bac88fb01e9127d47e241d8b16e52831c3a20e79e1c39; \
+            ;; \
+        'aarch64') \
+            URL=https://releases.hashicorp.com/terraform/1.3.10/terraform_1.3.10_linux_arm64.zip; \
+            SHA256=26dbff9a7d5de4ae0b3972fd62ff4784af6d5887833a91a88a013255c9069117; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+RUN apk add --no-cache jq
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client sshpass
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/1.3.10/Dockerfile
+++ b/variants/1.3.10/Dockerfile
@@ -1,0 +1,49 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=1.3.10; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/1.3.10/terraform_1.3.10_linux_386.zip; \
+            SHA256=b8a3db560c9b7369066c423f302d00bf0643b7a89748948b778476e3dad5dcd2; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/1.3.10/terraform_1.3.10_linux_amd64.zip; \
+            SHA256=2e3931c3db6999cdd4c7e55227cb877c6946d1f52923d7d057036d2827311402; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/1.3.10/terraform_1.3.10_linux_arm.zip; \
+            SHA256=5b51a3a601af0c7b3e2bac88fb01e9127d47e241d8b16e52831c3a20e79e1c39; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/1.3.10/terraform_1.3.10_linux_arm.zip; \
+            SHA256=5b51a3a601af0c7b3e2bac88fb01e9127d47e241d8b16e52831c3a20e79e1c39; \
+            ;; \
+        'aarch64') \
+            URL=https://releases.hashicorp.com/terraform/1.3.10/terraform_1.3.10_linux_arm64.zip; \
+            SHA256=26dbff9a7d5de4ae0b3972fd62ff4784af6d5887833a91a88a013255c9069117; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/1.4.7-jq-libvirt-sops-ssh/Dockerfile
+++ b/variants/1.4.7-jq-libvirt-sops-ssh/Dockerfile
@@ -1,0 +1,63 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=1.4.7; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/1.4.7/terraform_1.4.7_linux_386.zip; \
+            SHA256=8dab06a286ab399288950bd144525f8be2527975cfbc9a695c3faf0fc162d02c; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/1.4.7/terraform_1.4.7_linux_amd64.zip; \
+            SHA256=247c75658065b8691e19455f79969f583029f905a37026489f22c56a8830b8b2; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/1.4.7/terraform_1.4.7_linux_arm.zip; \
+            SHA256=5f258d7deb2bf0c6bd55af8e9d88519b78ca91f66e13c7dda9fbe3591d842604; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/1.4.7/terraform_1.4.7_linux_arm.zip; \
+            SHA256=5f258d7deb2bf0c6bd55af8e9d88519b78ca91f66e13c7dda9fbe3591d842604; \
+            ;; \
+        'aarch64') \
+            URL=https://releases.hashicorp.com/terraform/1.4.7/terraform_1.4.7_linux_arm64.zip; \
+            SHA256=5f8a31bbb391b2044e992975290d8fb1bf4f7996c84a40c91ea521b9cb0b5791; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+RUN apk add --no-cache jq
+
+RUN apk add --no-cache libvirt-client
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client sshpass
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/1.4.7-jq-sops-ssh/Dockerfile
+++ b/variants/1.4.7-jq-sops-ssh/Dockerfile
@@ -1,0 +1,61 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=1.4.7; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/1.4.7/terraform_1.4.7_linux_386.zip; \
+            SHA256=8dab06a286ab399288950bd144525f8be2527975cfbc9a695c3faf0fc162d02c; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/1.4.7/terraform_1.4.7_linux_amd64.zip; \
+            SHA256=247c75658065b8691e19455f79969f583029f905a37026489f22c56a8830b8b2; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/1.4.7/terraform_1.4.7_linux_arm.zip; \
+            SHA256=5f258d7deb2bf0c6bd55af8e9d88519b78ca91f66e13c7dda9fbe3591d842604; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/1.4.7/terraform_1.4.7_linux_arm.zip; \
+            SHA256=5f258d7deb2bf0c6bd55af8e9d88519b78ca91f66e13c7dda9fbe3591d842604; \
+            ;; \
+        'aarch64') \
+            URL=https://releases.hashicorp.com/terraform/1.4.7/terraform_1.4.7_linux_arm64.zip; \
+            SHA256=5f8a31bbb391b2044e992975290d8fb1bf4f7996c84a40c91ea521b9cb0b5791; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+RUN apk add --no-cache jq
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client sshpass
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/1.4.7/Dockerfile
+++ b/variants/1.4.7/Dockerfile
@@ -1,0 +1,49 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=1.4.7; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/1.4.7/terraform_1.4.7_linux_386.zip; \
+            SHA256=8dab06a286ab399288950bd144525f8be2527975cfbc9a695c3faf0fc162d02c; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/1.4.7/terraform_1.4.7_linux_amd64.zip; \
+            SHA256=247c75658065b8691e19455f79969f583029f905a37026489f22c56a8830b8b2; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/1.4.7/terraform_1.4.7_linux_arm.zip; \
+            SHA256=5f258d7deb2bf0c6bd55af8e9d88519b78ca91f66e13c7dda9fbe3591d842604; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/1.4.7/terraform_1.4.7_linux_arm.zip; \
+            SHA256=5f258d7deb2bf0c6bd55af8e9d88519b78ca91f66e13c7dda9fbe3591d842604; \
+            ;; \
+        'aarch64') \
+            URL=https://releases.hashicorp.com/terraform/1.4.7/terraform_1.4.7_linux_arm64.zip; \
+            SHA256=5f8a31bbb391b2044e992975290d8fb1bf4f7996c84a40c91ea521b9cb0b5791; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/1.5.7-jq-libvirt-sops-ssh/Dockerfile
+++ b/variants/1.5.7-jq-libvirt-sops-ssh/Dockerfile
@@ -1,0 +1,63 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=1.5.7; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/1.5.7/terraform_1.5.7_linux_386.zip; \
+            SHA256=106e4a9a237aea70f9dd2d4f84f0bcf795aa05227bf4ba8790a623f1d7e94950; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/1.5.7/terraform_1.5.7_linux_amd64.zip; \
+            SHA256=c0ed7bc32ee52ae255af9982c8c88a7a4c610485cf1d55feeb037eab75fa082c; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/1.5.7/terraform_1.5.7_linux_arm.zip; \
+            SHA256=fd77cd3ba76175ecf7554fdf5fb66548f5906cb4944bc7e180b4be0b2196f404; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/1.5.7/terraform_1.5.7_linux_arm.zip; \
+            SHA256=fd77cd3ba76175ecf7554fdf5fb66548f5906cb4944bc7e180b4be0b2196f404; \
+            ;; \
+        'aarch64') \
+            URL=https://releases.hashicorp.com/terraform/1.5.7/terraform_1.5.7_linux_arm64.zip; \
+            SHA256=f4b4ad7c6b6088960a667e34495cae490fb072947a9ff266bf5929f5333565e4; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+RUN apk add --no-cache jq
+
+RUN apk add --no-cache libvirt-client
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client sshpass
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/1.5.7-jq-sops-ssh/Dockerfile
+++ b/variants/1.5.7-jq-sops-ssh/Dockerfile
@@ -1,0 +1,61 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=1.5.7; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/1.5.7/terraform_1.5.7_linux_386.zip; \
+            SHA256=106e4a9a237aea70f9dd2d4f84f0bcf795aa05227bf4ba8790a623f1d7e94950; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/1.5.7/terraform_1.5.7_linux_amd64.zip; \
+            SHA256=c0ed7bc32ee52ae255af9982c8c88a7a4c610485cf1d55feeb037eab75fa082c; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/1.5.7/terraform_1.5.7_linux_arm.zip; \
+            SHA256=fd77cd3ba76175ecf7554fdf5fb66548f5906cb4944bc7e180b4be0b2196f404; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/1.5.7/terraform_1.5.7_linux_arm.zip; \
+            SHA256=fd77cd3ba76175ecf7554fdf5fb66548f5906cb4944bc7e180b4be0b2196f404; \
+            ;; \
+        'aarch64') \
+            URL=https://releases.hashicorp.com/terraform/1.5.7/terraform_1.5.7_linux_arm64.zip; \
+            SHA256=f4b4ad7c6b6088960a667e34495cae490fb072947a9ff266bf5929f5333565e4; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+RUN apk add --no-cache jq
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client sshpass
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]

--- a/variants/1.5.7/Dockerfile
+++ b/variants/1.5.7/Dockerfile
@@ -1,0 +1,49 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+# Install terraform
+RUN set -eux; \
+    TERRAFORM_VERSION=1.5.7; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://releases.hashicorp.com/terraform/1.5.7/terraform_1.5.7_linux_386.zip; \
+            SHA256=106e4a9a237aea70f9dd2d4f84f0bcf795aa05227bf4ba8790a623f1d7e94950; \
+            ;; \
+        'x86_64') \
+            URL=https://releases.hashicorp.com/terraform/1.5.7/terraform_1.5.7_linux_amd64.zip; \
+            SHA256=c0ed7bc32ee52ae255af9982c8c88a7a4c610485cf1d55feeb037eab75fa082c; \
+            ;; \
+        'armhf') \
+            URL=https://releases.hashicorp.com/terraform/1.5.7/terraform_1.5.7_linux_arm.zip; \
+            SHA256=fd77cd3ba76175ecf7554fdf5fb66548f5906cb4944bc7e180b4be0b2196f404; \
+            ;; \
+        'armv7l') \
+            URL=https://releases.hashicorp.com/terraform/1.5.7/terraform_1.5.7_linux_arm.zip; \
+            SHA256=fd77cd3ba76175ecf7554fdf5fb66548f5906cb4944bc7e180b4be0b2196f404; \
+            ;; \
+        'aarch64') \
+            URL=https://releases.hashicorp.com/terraform/1.5.7/terraform_1.5.7_linux_arm64.zip; \
+            SHA256=f4b4ad7c6b6088960a667e34495cae490fb072947a9ff266bf5929f5333565e4; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=terraform.zip; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    unzip "$FILE" terraform; \
+    mkdir -pv /usr/local/bin; \
+    mv -v terraform /usr/local/bin/terraform; \
+    chmod +x /usr/local/bin/terraform; \
+    CHECKPOINT_DISABLE=1 terraform version; \
+    :
+
+RUN apk add --no-cache ca-certificates
+
+# Disable telemetry. See: https://developer.hashicorp.com/terraform/cli/commands#upgrade-and-security-bulletin-checks
+ENV CHECKPOINT_DISABLE=1
+
+CMD [ "terraform" ]


### PR DESCRIPTION
Docker image tag conventions are starting to become clear that it is preferred to omit `v` prefix. While having the `v` prefix in the past might have been common, it is becoming less and less common today, with most of docker official images
(https://github.com/docker-library/official-images) omitting the `v` prefix.
